### PR TITLE
fix: ezcurl ~content requires polymorphic variant

### DIFF
--- a/engine/ocaml/bin/provider.ml
+++ b/engine/ocaml/bin/provider.ml
@@ -91,7 +91,7 @@ let call_provider ~config ~system_message ~user_message =
   let url = api_url config in
   let content = build_request_body ~config ~system_message ~user_message in
   let headers = build_headers config in
-  match Ezcurl.post ~url ~headers ~content () with
+  match Ezcurl.post ~url ~headers ~content:(`String content) ~params:[] () with
   | Ok response ->
     if response.Ezcurl.code >= 200 && response.Ezcurl.code < 300 then
       Ok response.Ezcurl.body


### PR DESCRIPTION
## Gap

`Ezcurl.post` expects `~content:(\`String s)`, not a bare string. Build fails at `provider.ml:94`:

```
This expression has type string but an expression was expected of type
  [ \`String of string | \`Write of bytes -> int -> int ]
```

## Fix

Wrap `content` in `\`String` constructor.

## Verification

CI build job should pass.