### PR TITLE
fix(ci/katas): switch from opam install to dune build + direct binary path

### DIFF
--- a/.github/workflows/katas.yml
+++ b/.github/workflows/katas.yml
@@ -75,9 +75,21 @@ jobs:
         working-directory: engine/ocaml
         run: opam install . --deps-only -y
 
-      - name: Install engine (provides `coh` on PATH)
+      - name: Build engine
+        # Mirrors ci.yml::build — `dune build` produces the binary at
+        # engine/ocaml/_build/default/bin/main.exe.
+        #
+        # Earlier (post-#36-merge) the step here was `opam install . -y`
+        # to put `coh` on PATH. That step failed on the first main run
+        # with exit 31. Root cause: opam's package-mode build (`dune
+        # build -p name @install`) treats the extracted package source
+        # as its root, but the bin/dune `build_version.ml` rule depends
+        # on `../../../VERSION` which resolves to outside-the-package
+        # in opam's build sandbox. Switching to bare `dune build` in
+        # the engine working directory avoids the package-mode
+        # constraint; the kata loop invokes the binary by direct path.
         working-directory: engine/ocaml
-        run: opam install . -y
+        run: opam exec -- dune build
 
       # AC2 — auto-discovery. The glob `katas/*/` matches *directories only*,
       # so `katas/README.md` is skipped naturally. Each iteration uses the
@@ -86,18 +98,29 @@ jobs:
       # katas/README.md §Directory layout). No kata names are hard-coded
       # here — Phase 2 katas (#34) auto-attach when their directories land.
       #
-      # `set -e` (default for `run:`) means any non-zero `coh --kata` exit
-      # fails the step — AC1's "fail CI on any kata failure" invariant.
+      # Binary invocation: direct path to the dune build output rather
+      # than relying on `coh` being on PATH. Matches the canonical
+      # tsc.yml pattern (which uses `dune exec` but resolves the same
+      # binary). Direct-path is slightly less portable but avoids any
+      # dependency on opam-install vs dune-install state.
+      #
+      # `set -e` (default for `run:`) means any non-zero exit fails the
+      # step — AC1's "fail CI on any kata failure" invariant.
       - name: Run all katas (auto-discovered)
         run: |
           shopt -s nullglob
+          COH="engine/ocaml/_build/default/bin/main.exe"
+          if [ ! -x "$COH" ]; then
+            echo "::error::engine binary not found at $COH — Build engine step probably failed"
+            exit 1
+          fi
           ran=0
           failed=0
           for kata_dir in katas/*/; do
             [ -f "${kata_dir}kata.toml" ] || continue
             id=$(basename "$kata_dir")
             echo "::group::kata $id"
-            if opam exec -- coh --kata "$id" --mode mechanical; then
+            if "$COH" --kata "$id" --mode mechanical; then
               echo "kata $id: PASS"
               ran=$((ran + 1))
             else


### PR DESCRIPTION
## Summary

Cycle #36's `katas.yml` workflow shipped on commit `9d5ffbb` and went red on its first main run — exit 31 at the "Install engine (provides `coh` on PATH)" step.

**Root cause:** `opam install . -y` triggers opam's package-mode build (`dune build -p name @install`), which treats the extracted package source as its root. The `bin/dune` `build_version.ml` rule depends on `../../../VERSION`, which resolves to *outside* the package source in opam's build sandbox.

**Fix:** mirror `ci.yml::build`'s working pattern.
- Replace `opam install . -y` with `opam exec -- dune build`
- Invoke katas via direct binary path `engine/ocaml/_build/default/bin/main.exe` instead of relying on `coh` being on PATH
- Defensive check verifies the binary exists before the kata loop

Reverts to known-good build pattern without changing the workflow's auto-discovery (AC2), cache (AC3), or triggers (AC1).

## Test plan

- [x] CI run on this PR turns green (the katas workflow runs on `pull_request:` trigger; verify here before merging)
- [ ] After merge, observe katas workflow runs green on main
- [ ] If still red, additional diagnosis needed

## Empirical anchor for the F2 follow-on

This failure is exactly what `proposals/cnos-cdd-ci-green-gate/ISSUE.md` was filed to catch. β R1 of cycle #36 APPROVED on artifact review alone; γ closed on artifact presence alone; CI ran red on first main push. With the proposed gate, β R1 would have refused APPROVED on red CI of the review SHA, and α would have caught the bug pre-merge.

The fix here addresses the immediate breakage. The protocol-level fix lives in `proposals/cycle-36-followons` / `proposals/cnos-cdd-ci-green-gate`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Qm6HLyjt4g1z3k9nqpb3r2)_