### PR TITLE
Ledger: release surface (tag + row) is main-only

### DIFF
--- a/.github/workflows/tsc-coherence-ledger.yml
+++ b/.github/workflows/tsc-coherence-ledger.yml
@@ -18,7 +18,9 @@ on:
     # Firing on the bump (and on this workflow's own installation) makes
     # the ledger record patch increments even when the tag arrives later
     # or from an environment that cannot push tags. The append is
-    # idempotent, so overlapping triggers are no-ops.
+    # idempotent, so overlapping triggers are no-ops. Non-main branch
+    # pushes run measurement only — the release surface (tag + ledger
+    # row) is guarded to main in the append step.
     branches:
       - '**'
     paths:
@@ -419,6 +421,25 @@ jobs:
       - name: Append ledger row and push
         run: |
           set -euo pipefail
+          # The authoritative release surface is main: only a main push, a
+          # tag push, or a main-ref dispatch may materialize a release tag
+          # or write the release ledger. A VERSION-bump push on any other
+          # branch still measures (the steps above; reports are artifacts)
+          # but stops here — a run started at an older SHA would otherwise
+          # tag and measure a tree the branch has already moved past, then
+          # rebase that stale row onto the advanced head (the 0.11.0
+          # tag/row race). The release is cut by the merge itself.
+          if [ "${{ github.event_name }}" = "push" ] \
+             && [ "${{ github.ref_type }}" = "branch" ] \
+             && [ "${{ github.ref_name }}" != "main" ]; then
+            echo "branch push (${{ github.ref_name }}): measurement only — no tag, no ledger row; the release surface is main"
+            exit 0
+          fi
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] \
+             && [ "${{ github.ref_name }}" != "main" ]; then
+            echo "::error::workflow_dispatch must run on main (got ${{ github.ref_name }})"
+            exit 1
+          fi
           # Version resolution: explicit input > tag name > VERSION file.
           if [ -n "${{ github.event.inputs.version }}" ]; then
             version="${{ github.event.inputs.version }}"

--- a/scripts/render-self-measure.sh
+++ b/scripts/render-self-measure.sh
@@ -609,7 +609,9 @@ on:
     # Firing on the bump (and on this workflow's own installation) makes
     # the ledger record patch increments even when the tag arrives later
     # or from an environment that cannot push tags. The append is
-    # idempotent, so overlapping triggers are no-ops.
+    # idempotent, so overlapping triggers are no-ops. Non-main branch
+    # pushes run measurement only — the release surface (tag + ledger
+    # row) is guarded to main in the append step.
     branches:
       - '**'
     paths:
@@ -648,6 +650,25 @@ jobs:
       - name: Append ledger row and push
         run: |
           set -euo pipefail
+          # The authoritative release surface is main: only a main push, a
+          # tag push, or a main-ref dispatch may materialize a release tag
+          # or write the release ledger. A VERSION-bump push on any other
+          # branch still measures (the steps above; reports are artifacts)
+          # but stops here — a run started at an older SHA would otherwise
+          # tag and measure a tree the branch has already moved past, then
+          # rebase that stale row onto the advanced head (the 0.11.0
+          # tag/row race). The release is cut by the merge itself.
+          if [ "${{{{ github.event_name }}}}" = "push" ] \\
+             && [ "${{{{ github.ref_type }}}}" = "branch" ] \\
+             && [ "${{{{ github.ref_name }}}}" != "main" ]; then
+            echo "branch push (${{{{ github.ref_name }}}}): measurement only — no tag, no ledger row; the release surface is main"
+            exit 0
+          fi
+          if [ "${{{{ github.event_name }}}}" = "workflow_dispatch" ] \\
+             && [ "${{{{ github.ref_name }}}}" != "main" ]; then
+            echo "::error::workflow_dispatch must run on main (got ${{{{ github.ref_name }}}})"
+            exit 1
+          fi
           # Version resolution: explicit input > tag name > VERSION file.
           if [ -n "${{{{ github.event.inputs.version }}}}" ]; then
             version="${{{{ github.event.inputs.version }}}}"

--- a/skills/self-measure/SKILL.md
+++ b/skills/self-measure/SKILL.md
@@ -425,7 +425,12 @@ exist yet; releases themselves are cut by `scripts/release.sh`, which
 gates on a `CHANGELOG.md` entry) — via
 [scripts/coherence-ledger.sh](../../scripts/coherence-ledger.sh);
 commits between releases do not write the ledger (per-run reports are CI
-artifacts instead). Historical rows were backfilled by measuring each
+artifacts instead). The authoritative release surface is `main`: only a
+`main` push, a tag push, or a `main`-ref dispatch materializes a tag or
+writes the row. A `VERSION`-bump push on any other branch measures and
+uploads artifacts but writes nothing — a run started at an older SHA
+would otherwise tag and record a tree the branch had already moved
+past; the release is cut by the merge itself. Historical rows were backfilled by measuring each
 tag's tree — its own `targets/registry.tsc` — with one fixed engine, so
 the curve is comparable across releases; the instrument column names the
 engine that measured each row.


### PR DESCRIPTION
## Description

The release-process fix from the 0.11.0 post-merge review: the ledger workflow refuses to materialize release tags or append release rows from non-main branch pushes. Branch runs still measure and upload artifacts; `workflow_dispatch` must run on a `main` ref. The PR #61 description said "the release is cut by the merge itself" — the workflow now enforces it.

What it closes: the branch-side ledger run for 0.11.0 started at `7ffbf36`, tagged its own (by then stale) SHA, computed the row from that tree, and rebase-pushed the row onto a branch that had already advanced to `c9680ae` (the registry-test fix). The push hardening saved the push — and thereby preserved the semantic race. With this guard, that run would have stopped after measuring, and the tag/row would have been produced by the main-side run at the merged history.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `scripts/render-self-measure.sh` (renderer authority): the "Append ledger row and push" step template gains the main-only guard — non-main branch push exits 0 after measurement ("no tag, no ledger row; the release surface is main"); non-main dispatch fails with an error. Trigger comment updated.
- `.github/workflows/tsc-coherence-ledger.yml`: re-rendered from the template (DO-NOT-EDIT artifact).
- `skills/self-measure/SKILL.md` §6: the ledger contract now declares the authoritative release surface is `main` and why.

## Testing

**Test commands run:**

```bash
scripts/render-self-measure.sh --check       # all three rendered artifacts clean
scripts/ci/validate-skill-frontmatter.sh     # both skills vet
scripts/check-forbidden-wording.sh           # pass
```

**New tests added:**

- [x] No (explain why not): the change is a guard clause in a rendered workflow step; its executable check is the renderer drift check (`--check`), which CI runs. Engine code untouched.

**Manual testing performed:**

Inspected the rendered guard in the workflow output; verified the three guard conditions (`push`+`branch`+non-main → exit 0; `workflow_dispatch`+non-main → error; tag push / main push / main dispatch → unchanged path).

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] New and existing unit tests pass locally with my changes (`dune runtest`)
- [x] I have updated CHANGELOG.md (if this is a significant change) — not significant enough for a ledger row; will ride the next release note

## For New Parsers

N/A.

## Breaking Changes

None for consumers. Process change: a release ledger row / tag can no longer be produced from a feature branch.

## Additional Context

Remediation of the already-cut 0.11.0 tag/row (tag at `7ffbf36`, row measured from that tree) is a separate decision being taken with the maintainer — this PR only prevents recurrence.

## Reviewer Notes

The guard is in the step (not the trigger) deliberately: branch VERSION-bump pushes still run the full k=3 measurement as a rehearsal with artifacts, which is what caught the witness-consistency regression on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ks8wtULXPtFaehDbnEGgdr

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ks8wtULXPtFaehDbnEGgdr)_