### PR TITLE
Issue B — Spec v3.2.2: τ_lip verdict consistency + notation-window closure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@
 
 The spec lineage (C≡, TSC Core, TSC Operational, TSC Glossary, TSC Observation Dynamics) versions independently from the engine. Spec releases are theory work with no binary deployment; validation is mathematical reproduction and cross-spec consistency.
 
+### Spec v3.2.2 (2026-07-04) — τ_lip Verdict Consistency + Notation-Window Closure
+
+Coherence delta: docs-only patch · **Level:** L6
+
+Two correctness defects in `spec/tsc-oper.md`, both surfaced repeatedly by the self-measurement witness (τ_lip found by 4/5 witnesses at k=5; the stale window by 5/5 — the corpus's most consistently discovered defects):
+
+1. **τ_lip verdict contradiction.** §5 Verdict Logic condition 6 read `w_lip < 1` while §2's floor table (and the glossary) require `w_lip ≤ τ_lip = 0.95` — the two disagreed on PASS/FAIL for κ ∈ (0.95, 1). Condition 6 and §1's witness-suite summary now state the floor rule (`w_lip ≤ τ_lip`; τ_lip < 1, so passing implies contraction). The floor table was already normative; no threshold value changed.
+2. **Stale notation-migration window.** §5's Compatibility Note granted legacy-key emission "through v3.1" inside a document versioned past that window. The note is now explicitly historical: the emission window is closed (the canonical engine never emitted legacy keys); consumer-side fallback for pre-v3.2 reports remains documented.
+
+**Affected:** `spec/tsc-oper.md` (header v3.2.1 → v3.2.2; §1, §5 verdict logic, §5 compatibility note; end-marker), `spec/tsc-glossary.md` (corresponds-to, read-guide, migration note), `spec/tsc-observation-dynamics.md` (corresponds-to). `spec/tsc-core.md` and C≡ unchanged. Content correctness fix — not a meter-improvement iteration; no score claim.
+
 ### Spec v3.2.1 (2026-05-09) — Cross-Target Aggregate Canonicalization
 
 Coherence delta: docs-only patch · **Level:** L6

--- a/spec/tsc-glossary.md
+++ b/spec/tsc-glossary.md
@@ -2,7 +2,7 @@
 
 **Version:** v3.2.0 (Triadic Foundation + Measurement Framework + Barrier Transform)\
 **Status:** Informative (accessible terminology guide)\
-**Corresponds to:** C≡ v3.1.0, TSC Core v3.2.0, TSC Operational v3.2.1, TSC Observation Dynamics v1.0.13\
+**Corresponds to:** C≡ v3.1.0, TSC Core v3.2.0, TSC Operational v3.2.2, TSC Observation Dynamics v1.0.13\
 **Changelog:** `CHANGELOG.md` § Spec releases
 
 ______________________________________________________________________
@@ -1038,7 +1038,7 @@ ______________________________________________________________________
 Read **C≡ v3.1.0** from beginning to end. It unfolds like a story: from intuition (§0-1) through formalization (§2-4) to measurement (§5). Follow the complete arc.
 
 **To implement measurement:**\
-Read **TSC Core v3.2.0** for the calculus—how to construct summaries, compute alignments, aggregate coherence. Then **TSC Operational v3.2.1** for the protocol—witnesses, verdicts, provenance requirements.
+Read **TSC Core v3.2.0** for the calculus—how to construct summaries, compute alignments, aggregate coherence. Then **TSC Operational v3.2.2** for the protocol—witnesses, verdicts, provenance requirements.
 
 **To see it in action:**\
 Explore `examples/`—cellular automata (Conway's Life, random soup) and philosophical queries (consciousness, emergence, free will). These show TSC measuring real phenomena, not toy problems.
@@ -1053,7 +1053,7 @@ ______________________________________________________________________
 
 ## Legacy Notation Note
 
-**For implementers migrating from earlier versions:** Dimensional scores were previously notated as α_c, β_c, γ_c in some documents. These are now unified as **s_α, s_β, s_γ** across all specifications for consistency with the C≡ foundation. In wire formats (JSON/YAML), use ASCII keys: `s_alpha`, `s_beta`, `s_gamma`. One-cycle compatibility support (reading both notations) is documented in Operational v3.2.1.
+**For implementers migrating from earlier versions:** Dimensional scores were previously notated as α_c, β_c, γ_c in some documents. These are now unified as **s_α, s_β, s_γ** across all specifications for consistency with the C≡ foundation. In wire formats (JSON/YAML), use ASCII keys: `s_alpha`, `s_beta`, `s_gamma`. The one-cycle emission window (through v3.1) is closed; consumer-side fallback for reading pre-v3.2 reports is documented in Operational v3.2.2 §5 (Compatibility Note, historical).
 
 ______________________________________________________________________
 

--- a/spec/tsc-observation-dynamics.md
+++ b/spec/tsc-observation-dynamics.md
@@ -10,7 +10,7 @@ Changelog: `CHANGELOG.md` § Spec releases
 Normative dependencies:
     C≡ v3.1.0
     TSC Core v3.2.0
-    TSC Operational v3.2.1
+    TSC Operational v3.2.2
 
 Compatibility note for v3.2.0 dependency uplift:
     TSC Core v3.2.0 introduces the Barrier-Coherence Link

--- a/spec/tsc-oper.md
+++ b/spec/tsc-oper.md
@@ -1,6 +1,6 @@
-# TSC Operational v3.2.1
+# TSC Operational v3.2.2
 
-**Version:** 3.2.1\
+**Version:** 3.2.2\
 **Status:** Normative\
 **Foundation:** TSC Core v3.2.0\
 **Changelog:** `CHANGELOG.md` § Spec releases
@@ -101,7 +101,7 @@ where L_link is the link-Lipschitz constant for the barrier+exponential coherenc
 **Test:**
 
 - Variance: Ensemble agreement high (variance low)
-- Lipschitz: Contraction condition satisfied (κ < 1)
+- Lipschitz: Contraction margin satisfied (κ ≤ τ_lip; τ_lip < 1, so passing implies contraction)
 
 **Purpose:** Detect unstable alignments (high variance) or non-contractive updates.
 
@@ -220,7 +220,7 @@ ______________________________________________________________________
 3b. w_gauge_spread ≤ τ_gauge_spread                  (permutation-insensitive)
 4. w_scale ≤ τ_scale                                 (scale equivariance)
 5. w_var ≤ τ_var                                     (ensemble stability)
-6. w_lip < 1                                         (contraction; w_lip uses L_link)
+6. w_lip ≤ τ_lip                                     (contraction with margin; w_lip uses L_link)
 7. CIₕᵢ - CIₗₒ ≤ δ_CI                                (precision)
 8. Zₜ < Zcᵣᵢₜ                                        (distribution stability)
 ```
@@ -243,12 +243,13 @@ ______________________________________________________________________
 
 ### Compatibility Note (Notation Migration)
 
-For one minor release cycle (through v3.1), implementations MAY emit both:
-
-- **Canonical keys:** `s_alpha`, `s_beta`, `s_gamma` (required)
-- **Legacy keys:** `alpha_c`, `beta_c`, `gamma_c` (optional, for backward compatibility)
-
-Consumers MUST read canonical keys; MAY fall back to legacy keys if canonical absent. All new implementations MUST use canonical notation.
+**Historical (window closed with v3.1):** for one minor release cycle
+(through v3.1), implementations were permitted to emit both canonical
+keys (`s_alpha`, `s_beta`, `s_gamma`) and legacy keys (`alpha_c`,
+`beta_c`, `gamma_c`). That window is closed: implementations MUST emit
+canonical keys only (the canonical engine never emitted legacy keys).
+Consumers reading pre-v3.2 reports MAY still fall back to legacy keys
+when canonical keys are absent.
 
 ## 6 · Provenance Bundle
 
@@ -488,4 +489,4 @@ ______________________________________________________________________
 
 ______________________________________________________________________
 
-**End — TSC Operational v3.2.1**
+**End — TSC Operational v3.2.2**


### PR DESCRIPTION
## Description

Second PR of the meter-v3.2.4-prep wave: the spec correctness one-off (mode: design-and-build, docs/spec-only). **This is a content correctness fix, not a meter-improvement iteration** — no protocol, sample-count, or standing change, no score claim, no loop-counter effect.

The two defects were the corpus's most consistently witness-discovered at k=5 (τ_lip: 4/5 witnesses; stale window: 5/5 — unanimous):

1. **τ_lip verdict contradiction (AC1).** `tsc-oper.md` §5 Verdict Logic condition 6 read `w_lip < 1` while §2's floor table and `tsc-glossary.md` both require `w_lip ≤ τ_lip = 0.95` — the same κ = 0.97 passed one section and failed the other. Condition 6 and §1's witness-suite summary now state the floor rule; the floor table was already normative, so no threshold value changed anywhere.
2. **Stale "through v3.1" window (AC2).** §5's Compatibility Note granted legacy-key emission "through v3.1" inside a document versioned v3.2.1. Now explicitly historical: the emission window is closed (verified: the canonical engine never emitted `alpha_c`/`beta_c`/`gamma_c`), consumer-side fallback for pre-v3.2 reports stays documented.

Version bump v3.2.1 → v3.2.2 with the full reference sweep: header, self-corresponds-to, end marker, glossary (corresponds-to + read-guide + migration note), observation-dynamics corresponds-to, and a CHANGELOG spec-release entry.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Documentation update

## Changes Made

- `spec/tsc-oper.md`: §1 summary line, §5 condition 6, §5 compatibility note, version surfaces
- `spec/tsc-glossary.md`, `spec/tsc-observation-dynamics.md`: corresponds-to sweep
- `CHANGELOG.md`: Spec v3.2.2 entry

## Testing

**Test commands run:**

```bash
rg "through v3\.1" spec runtime skills docs README.md CHANGELOG.md
  # every hit historical/labeled (AC2); docs/alpha snapshots frozen by policy
scripts/check-forbidden-wording.sh
scripts/ci/validate-skill-frontmatter.sh
coh --mode mechanical --target spec   # spec target still measures clean (0.982)
# relative-link scan over changed files: none broken
```

**New tests added:**

- [x] N/A — spec prose only; the verdict rule has no executable surface in this repo (the engine emits witness signals; verdict logic is spec-level)

**Manual testing performed:**

Verified both §2 and §5 now state one rule; verified the engine source has no legacy-key emission; AC1 satisfied — the same condition can no longer both pass and fail.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have updated CHANGELOG.md (if this is a significant change)

## Breaking Changes

None. τ_lip's value (0.95) is unchanged; only the contradictory restatement was corrected.

## Additional Context

Scope discipline per the issue: no unrelated spec cleanup (the k=5 pass found other spec defects — ε attribution, W2 misattribution, Core §2.1 citation — deliberately NOT touched here; they queue separately). Issues C and D follow.

## Reviewer Notes

The rejection rule was "reject if the PR touches meter protocol, sample count, standing policy, or unrelated spec surfaces" — the diff is 4 files, all named in the issue's source-of-truth table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ks8wtULXPtFaehDbnEGgdr

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ks8wtULXPtFaehDbnEGgdr)_