### PR TITLE
Issue C: auto-mode credential detection agrees with the provider route

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ See the [operator manual](docs/beta/guides/OPERATOR-MANUAL.md) for configuration
 | `mechanical` | No | Deterministic structural-proxy scoring. Works offline and in CI. |
 | `llm` | Yes | Semantic scoring via `runtime/SELF-MEASURE.md`. |
 | `hybrid` | Yes | Runs both backends; report contains `mechanical`, `llm`, and `final` sub-objects. |
-| `auto` | Optional | `hybrid` when credentials are present; `mechanical` otherwise. (Default.) |
+| `auto` | Optional | `hybrid` when the full provider configuration (`LLM_PROVIDER`, `LLM_MODEL`, `LLM_API_KEY`) is present; `mechanical` otherwise — a partial set warns with the missing names and falls back. (Default.) |
 
 Direct file input (`--files <glob>`) works with any mode. Named targets (`--target`) require `--registry`.
 
@@ -56,7 +56,7 @@ TSC measures itself:
 
 ```bash
 coh self --mode mechanical   # deterministic, offline, no credentials
-coh self                     # auto: hybrid when LLM credentials are present
+coh self                     # auto: hybrid when the full LLM provider config is present
 ```
 
 The whole procedure — which steps are fully mechanical and exactly what

--- a/docs/beta/guides/OPERATOR-MANUAL.md
+++ b/docs/beta/guides/OPERATOR-MANUAL.md
@@ -8,7 +8,7 @@ This manual covers building, configuring, and running the TSC engine.
 
 The engine measures triadic self-coherence of a target in one of four
 modes — `mechanical` | `llm` | `hybrid` | `auto` (the default: `hybrid`
-when LLM credentials are present, `mechanical` otherwise). It:
+when the full provider configuration — `LLM_PROVIDER`, `LLM_MODEL`, `LLM_API_KEY` — is present, `mechanical` otherwise; a partial set warns with the missing variable names and falls back). It:
 
 1. Resolves input — a named target from the registry, direct file globs
    (`--files`), or a kata (`--kata`)

--- a/engine/ocaml/bin/main.ml
+++ b/engine/ocaml/bin/main.ml
@@ -6,7 +6,9 @@
       mechanical  — structural-proxy scoring, no credentials required
       llm         — semantic scoring via SELF-MEASURE.md (default before v0.5.0)
       hybrid      — run both backends, produce unified report
-      auto        — hybrid when credentials are present, else mechanical
+      auto        — hybrid when the FULL provider configuration
+                    (LLM_PROVIDER, LLM_MODEL, LLM_API_KEY) is present;
+                    partial sets warn and fall back to mechanical
 
     Inputs:
       --target <name> --registry <path>    named target (any mode); repeatable
@@ -914,10 +916,23 @@ let () =
         Hybrid
       end
       else if Tsc_engine.Credentials.has_llm_credentials () then begin
-        Printf.eprintf "Auto mode: credentials found — running hybrid.\n%!";
+        Printf.eprintf
+          "Auto mode: full provider configuration found — running hybrid.\n%!";
         Hybrid
       end else begin
-        Printf.eprintf "Auto mode: no credentials — running mechanical.\n%!";
+        (* A partial provider configuration is a misconfiguration, not
+           a credential: hybrid would fail downstream after claiming
+           the semantic path. Say exactly what is missing, then run
+           the honest fallback. *)
+        if Tsc_engine.Credentials.partial_llm_credentials () then
+          Printf.eprintf
+            "Auto mode: partial LLM configuration (missing %s) — running \
+             mechanical. Set all of %s for hybrid.\n%!"
+            (String.concat ", "
+               (Tsc_engine.Credentials.missing_llm_credentials ()))
+            (String.concat ", " Tsc_engine.Credentials.provider_env_vars)
+        else
+          Printf.eprintf "Auto mode: no credentials — running mechanical.\n%!";
         Mechanical
       end
     | m -> m

--- a/engine/ocaml/lib/credentials.ml
+++ b/engine/ocaml/lib/credentials.ml
@@ -1,4 +1,35 @@
-let has_llm_credentials () =
-  match Sys.getenv_opt "LLM_API_KEY" with
-  | Some v when String.length v > 0 -> true
-  | _ -> false
+(** Local LLM credential detection for auto-mode.
+
+    "Credentials present" means the FULL provider configuration the
+    HTTP route requires — LLM_PROVIDER, LLM_MODEL, and LLM_API_KEY all
+    non-empty (bin/provider.ml, config_from_env, needs all three). A
+    partial set must never route auto into hybrid: the provider call
+    would fail downstream after the run already claimed the semantic
+    path. Auto-mode surfaces a partial set as a visible warning naming
+    the missing variables, then runs mechanical (Issue C of the
+    meter-v3.2.4-prep wave — the k=5 audit found detection keyed on
+    LLM_API_KEY alone).
+
+    ANTHROPIC_API_KEY is deliberately NOT part of this contract: it is
+    the CI witness secret shape (routed by the rendered workflows),
+    not the engine's local provider route. *)
+
+let provider_env_vars = [ "LLM_PROVIDER"; "LLM_MODEL"; "LLM_API_KEY" ]
+
+(** Names of the provider variables that are unset or empty. *)
+let missing_llm_credentials () =
+  List.filter
+    (fun v ->
+      match Sys.getenv_opt v with
+      | Some s when String.length s > 0 -> false
+      | _ -> true)
+    provider_env_vars
+
+(** True iff the full provider configuration is present. *)
+let has_llm_credentials () = missing_llm_credentials () = []
+
+(** True iff SOME but not ALL provider variables are set — the
+    misconfiguration auto-mode must warn about instead of guessing. *)
+let partial_llm_credentials () =
+  let missing = missing_llm_credentials () in
+  missing <> [] && List.length missing < List.length provider_env_vars

--- a/engine/ocaml/test/test_mechanical.ml
+++ b/engine/ocaml/test/test_mechanical.ml
@@ -331,20 +331,51 @@ let test_hybrid_preserves_both () =
 (* AC8: Auto-mode fallback (Sub 2 AC11) *)
 
 let test_auto_mode_fallback () =
-  let saved = Sys.getenv_opt "LLM_API_KEY" in
+  (* Table-driven env-resolution contract (Issue C): "credentials
+     present" = the FULL provider triple; a partial set is flagged as
+     partial (auto warns + falls back), never treated as present.
+     ANTHROPIC_API_KEY is not part of the local contract. *)
+  let vars = Tsc_engine.Credentials.provider_env_vars in
+  let saved = List.map (fun v -> (v, Sys.getenv_opt v)) vars in
   let restore () =
-    match saved with
-    | Some v -> Unix.putenv "LLM_API_KEY" v
-    | None   -> Unix.putenv "LLM_API_KEY" ""
+    List.iter (fun (v, ov) ->
+      Unix.putenv v (match ov with Some x -> x | None -> "")) saved
   in
-  (* No credentials: credential check must return false *)
-  Unix.putenv "LLM_API_KEY" "";
-  check (not (Tsc_engine.Credentials.has_llm_credentials ()))
-    "AC8: empty LLM_API_KEY → no credentials (auto falls back to mechanical)";
-  (* With a non-empty key: credential check must return true *)
-  Unix.putenv "LLM_API_KEY" "test-key-abc";
-  check (Tsc_engine.Credentials.has_llm_credentials ())
-    "AC8: non-empty LLM_API_KEY → credentials present (auto takes hybrid path)";
+  let set_env provider model key =
+    Unix.putenv "LLM_PROVIDER" provider;
+    Unix.putenv "LLM_MODEL" model;
+    Unix.putenv "LLM_API_KEY" key
+  in
+  let cases = [
+    (* provider, model, key,       has,   partial, label *)
+    ("",          "",      "",      false, false,
+     "no env -> mechanical (not partial)");
+    ("anthropic", "claude", "sk-x", true,  false,
+     "full triple -> hybrid");
+    ("",          "",      "sk-x",  false, true,
+     "LLM_API_KEY only -> partial, NOT accidental hybrid");
+    ("anthropic", "claude", "",     false, true,
+     "provider+model without key -> partial, mechanical");
+    ("anthropic", "",      "",      false, true,
+     "provider only -> partial, mechanical");
+  ] in
+  List.iter (fun (pv, m, k, want_has, want_partial, label) ->
+    set_env pv m k;
+    check (Tsc_engine.Credentials.has_llm_credentials () = want_has)
+      (Printf.sprintf "AC8/IssueC has: %s" label);
+    check (Tsc_engine.Credentials.partial_llm_credentials () = want_partial)
+      (Printf.sprintf "AC8/IssueC partial: %s" label)
+  ) cases;
+  (* ANTHROPIC_API_KEY alone is explicitly unsupported for the local
+     route: it must not flip detection in any direction. *)
+  set_env "" "" "";
+  let saved_ant = Sys.getenv_opt "ANTHROPIC_API_KEY" in
+  Unix.putenv "ANTHROPIC_API_KEY" "sk-ant-test";
+  check (not (Tsc_engine.Credentials.has_llm_credentials ())
+         && not (Tsc_engine.Credentials.partial_llm_credentials ()))
+    "AC8/IssueC: ANTHROPIC_API_KEY alone is not a local credential";
+  Unix.putenv "ANTHROPIC_API_KEY"
+    (match saved_ant with Some x -> x | None -> "");
   restore ();
   (* Mechanical scorer always returns Mechanical mode regardless of env *)
   let r = Mechanical_scoring.score_files sample_files in


### PR DESCRIPTION
## Description

Third PR of the meter-v3.2.4-prep wave. The mismatch reproduced exactly as the review suspected: `credentials.ml` keyed auto-mode on `LLM_API_KEY` alone while `provider.ml`'s `config_from_env` requires `LLM_PROVIDER` + `LLM_MODEL` + `LLM_API_KEY` — a key-only environment was misclassified into hybrid and failed downstream after claiming the semantic path.

**The contract now (AC1 table, all tested):**

| env | result |
|---|---|
| none | mechanical (not partial) |
| full triple | hybrid |
| `LLM_API_KEY` only | **warning naming missing vars → mechanical** (never accidental hybrid) |
| provider+model, no key | warning → mechanical |
| `ANTHROPIC_API_KEY` only | explicitly not a local credential (it's the CI witness secret shape; docs and code agree) |

**AC2** holds by construction: `has_llm_credentials` = exactly `config_from_env`'s preconditions, so auto never claims hybrid without a runnable provider path. **AC3**: README modes table, operator manual, and `main.ml`'s doc header all state the same contract. **AC4**: table-driven `putenv` tests, no network.

Verified live: a key-only environment prints `Auto mode: partial LLM configuration (missing LLM_PROVIDER, LLM_MODEL) — running mechanical. Set all of LLM_PROVIDER, LLM_MODEL, LLM_API_KEY for hybrid.` and produces a mechanical report.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `engine/ocaml/lib/credentials.ml`: `provider_env_vars` / `missing_llm_credentials` / `partial_llm_credentials`; `has_llm_credentials` = full triple
- `engine/ocaml/bin/main.ml`: auto branch warns with exact missing names; doc header updated
- `engine/ocaml/test/test_mechanical.ml`: table-driven env-resolution tests (11 assertions)
- `README.md`, `docs/beta/guides/OPERATOR-MANUAL.md`: contract wording

## Testing

**Test commands run:**

```bash
dune build && dune test               # incl. new table-driven AC8/IssueC cases
scripts/ci/self-measure-smoke.sh <coh>
scripts/render-self-measure.sh --check
scripts/check-forbidden-wording.sh
# live: key-only env → warning + mechanical; empty env → mechanical
```

**New tests added:**

- [x] Yes — 11 table-driven assertions over five env shapes plus the ANTHROPIC_API_KEY exclusion

**Manual testing performed:**

Both live auto-mode paths exercised against the fresh binary (output quoted above).

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`dune runtest`)
- [x] I have made corresponding changes to the documentation

## Breaking Changes

Behavioral: an environment with only `LLM_API_KEY` now runs mechanical (with a warning) instead of entering hybrid and erroring. This is the documented contract; no working configuration changes behavior.

## Additional Context

Out of scope per the issue: CI Claude CLI credential routing, OAuth handling, provider SDK, witness metrics. `coh-self --require-llm` keeps its existing loud refusal (it already lists all three variables). No score or standing claim; loop counter unchanged (1/2). Issue D is next and last.

## Reviewer Notes

Rejection rule was "docs and code disagree about which env vars count as credentials" — the three surfaces (code, README, manual) now quote the same triple verbatim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ks8wtULXPtFaehDbnEGgdr

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ks8wtULXPtFaehDbnEGgdr)_