### PR TITLE
Issue D: SELF-MEASURE v3.2.4 — structured defect cards + k-fair statistic (pre-registered experiment)

### DIFF
--- a/.github/workflows/tsc-coherence-ledger.yml
+++ b/.github/workflows/tsc-coherence-ledger.yml
@@ -180,21 +180,45 @@ jobs:
             fi
           done
           n=$(echo $valid | wc -w)
+          declared=3
+          refused=$((declared - n))
+          # Refusal-stage counts from the validation-failure artifacts the
+          # funnel wrote for the samples that did not validate.
+          stage_counts=$(cat ".tsc/self"/validate/tsc-$T-*-validation-failure.json 2>/dev/null \
+            | jq -cs 'map(.stage) | group_by(.) | map({(.[0]): length}) | add // {}' 2>/dev/null || echo '{}')
           # Defect-overlap observability: per validated sample, the checklist
           # counts and negative findings, one JSON line each — job logs carry
           # enough to cluster findings across samples without artifact access.
           for r in $valid; do
             jq -c '{sample: input_filename, checklist: (.axis_evidence | map_values(.checklist)), negative: (.axis_evidence | map_values(.negative))}' "$r" || true
           done
-          coh_c="0"
+          coh_c="0"; coh_kfair="0"
           if [ "$n" -ge 2 ]; then
             COH_BIN="$COH" scripts/cm-consistency.sh llm-spread "$T" $valid || true
-            coh_c=$(python3 -c "import json,sys; print(json.load(open(sys.argv[1]))['coh_consistency'])" ".tsc/cm/consistency/$T.llm.json" 2>/dev/null || echo 0)
+            coh_c=$(jq -r '.coh_consistency_max_pairwise' ".tsc/cm/consistency/$T.llm.json" 2>/dev/null || echo 0)
+            coh_kfair=$(jq -r '.coh_consistency_mean_pairwise' ".tsc/cm/consistency/$T.llm.json" 2>/dev/null || echo 0)
             cp ".tsc/cm/consistency/$T.llm.json" ".tsc/self/consistency-$T.json" 2>/dev/null || true
           fi
-          gate=$(python3 -c "import sys; print('passed' if float(sys.argv[1]) >= 0.9 else 'failed')" "$coh_c")
-          python3 -c "import json,sys; json.dump({'standing_scope': 'house-authored-public-commons', 'admissibility': 'public-only', 'heldout_status': 'none', 'external_anchor_count': 0, 'llm_consistency_gate': sys.argv[4], 'llm_consistency_floor': 0.9, 'coh_consistency': float(sys.argv[3]), 'validated_samples': int(sys.argv[2]), 'target': sys.argv[1]}, open('.tsc/self/standing-' + sys.argv[1] + '.json', 'w'), indent=2)" "$T" "$n" "$coh_c" "$gate"
-          echo "consistency: $T k=$n Coh_consistency=$coh_c gate=$gate (standing gate, never a publishing gate)"
+          # Standing gate: legacy max-pairwise vs the floor (conservative,
+          # unchanged). kfair_experiment_gate: the yield PRECONDITION only —
+          # a short sample set fails the k-fair experiment regardless of
+          # score; the numeric comparison vs baseline happens at close-out.
+          gate=$(awk -v c="$coh_c" 'BEGIN { if (c >= 0.9) print "passed"; else print "failed" }')
+          yield_gate=$([ "$n" -eq "$declared" ] && echo passed || echo failed)
+          jq -n --arg target "$T" --argjson declared "$declared" --argjson n "$n" \
+                --argjson refused "$refused" --argjson stages "$stage_counts" \
+                --argjson coh "$coh_c" --argjson kfair "$coh_kfair" \
+                --arg gate "$gate" --arg ygate "$yield_gate" \
+                '{standing_scope: "house-authored-public-commons", admissibility: "public-only",
+                  heldout_status: "none", external_anchor_count: 0,
+                  llm_consistency_gate: $gate, llm_consistency_floor: 0.9,
+                  coh_consistency: $coh,
+                  coh_consistency_max_pairwise: $coh, coh_consistency_mean_pairwise: $kfair,
+                  declared_samples: $declared, validated_samples: $n,
+                  refused_samples: $refused, refusal_stage_counts: $stages,
+                  kfair_experiment_gate: $ygate, target: $target}' \
+                > ".tsc/self/standing-$T.json"
+          echo "consistency: $T k=$n/$declared Coh_max=$coh_c Coh_kfair=$coh_kfair gate=$gate yield=$yield_gate (standing gate, never a publishing gate)"
 
       - name: Emit witness prompt (engine)
         if: ${{ env.CLAUDE_CODE_OAUTH_TOKEN != '' }}
@@ -306,21 +330,45 @@ jobs:
             fi
           done
           n=$(echo $valid | wc -w)
+          declared=3
+          refused=$((declared - n))
+          # Refusal-stage counts from the validation-failure artifacts the
+          # funnel wrote for the samples that did not validate.
+          stage_counts=$(cat ".tsc/self"/validate/tsc-$T-*-validation-failure.json 2>/dev/null \
+            | jq -cs 'map(.stage) | group_by(.) | map({(.[0]): length}) | add // {}' 2>/dev/null || echo '{}')
           # Defect-overlap observability: per validated sample, the checklist
           # counts and negative findings, one JSON line each — job logs carry
           # enough to cluster findings across samples without artifact access.
           for r in $valid; do
             jq -c '{sample: input_filename, checklist: (.axis_evidence | map_values(.checklist)), negative: (.axis_evidence | map_values(.negative))}' "$r" || true
           done
-          coh_c="0"
+          coh_c="0"; coh_kfair="0"
           if [ "$n" -ge 2 ]; then
             COH_BIN="$COH" scripts/cm-consistency.sh llm-spread "$T" $valid || true
-            coh_c=$(python3 -c "import json,sys; print(json.load(open(sys.argv[1]))['coh_consistency'])" ".tsc/cm/consistency/$T.llm.json" 2>/dev/null || echo 0)
+            coh_c=$(jq -r '.coh_consistency_max_pairwise' ".tsc/cm/consistency/$T.llm.json" 2>/dev/null || echo 0)
+            coh_kfair=$(jq -r '.coh_consistency_mean_pairwise' ".tsc/cm/consistency/$T.llm.json" 2>/dev/null || echo 0)
             cp ".tsc/cm/consistency/$T.llm.json" ".tsc/self/consistency-$T.json" 2>/dev/null || true
           fi
-          gate=$(python3 -c "import sys; print('passed' if float(sys.argv[1]) >= 0.9 else 'failed')" "$coh_c")
-          python3 -c "import json,sys; json.dump({'standing_scope': 'house-authored-public-commons', 'admissibility': 'public-only', 'heldout_status': 'none', 'external_anchor_count': 0, 'llm_consistency_gate': sys.argv[4], 'llm_consistency_floor': 0.9, 'coh_consistency': float(sys.argv[3]), 'validated_samples': int(sys.argv[2]), 'target': sys.argv[1]}, open('.tsc/self/standing-' + sys.argv[1] + '.json', 'w'), indent=2)" "$T" "$n" "$coh_c" "$gate"
-          echo "consistency: $T k=$n Coh_consistency=$coh_c gate=$gate (standing gate, never a publishing gate)"
+          # Standing gate: legacy max-pairwise vs the floor (conservative,
+          # unchanged). kfair_experiment_gate: the yield PRECONDITION only —
+          # a short sample set fails the k-fair experiment regardless of
+          # score; the numeric comparison vs baseline happens at close-out.
+          gate=$(awk -v c="$coh_c" 'BEGIN { if (c >= 0.9) print "passed"; else print "failed" }')
+          yield_gate=$([ "$n" -eq "$declared" ] && echo passed || echo failed)
+          jq -n --arg target "$T" --argjson declared "$declared" --argjson n "$n" \
+                --argjson refused "$refused" --argjson stages "$stage_counts" \
+                --argjson coh "$coh_c" --argjson kfair "$coh_kfair" \
+                --arg gate "$gate" --arg ygate "$yield_gate" \
+                '{standing_scope: "house-authored-public-commons", admissibility: "public-only",
+                  heldout_status: "none", external_anchor_count: 0,
+                  llm_consistency_gate: $gate, llm_consistency_floor: 0.9,
+                  coh_consistency: $coh,
+                  coh_consistency_max_pairwise: $coh, coh_consistency_mean_pairwise: $kfair,
+                  declared_samples: $declared, validated_samples: $n,
+                  refused_samples: $refused, refusal_stage_counts: $stages,
+                  kfair_experiment_gate: $ygate, target: $target}' \
+                > ".tsc/self/standing-$T.json"
+          echo "consistency: $T k=$n/$declared Coh_max=$coh_c Coh_kfair=$coh_kfair gate=$gate yield=$yield_gate (standing gate, never a publishing gate)"
 
       - name: Emit witness prompt (repo)
         if: ${{ env.CLAUDE_CODE_OAUTH_TOKEN != '' }}
@@ -432,21 +480,45 @@ jobs:
             fi
           done
           n=$(echo $valid | wc -w)
+          declared=3
+          refused=$((declared - n))
+          # Refusal-stage counts from the validation-failure artifacts the
+          # funnel wrote for the samples that did not validate.
+          stage_counts=$(cat ".tsc/self"/validate/tsc-$T-*-validation-failure.json 2>/dev/null \
+            | jq -cs 'map(.stage) | group_by(.) | map({(.[0]): length}) | add // {}' 2>/dev/null || echo '{}')
           # Defect-overlap observability: per validated sample, the checklist
           # counts and negative findings, one JSON line each — job logs carry
           # enough to cluster findings across samples without artifact access.
           for r in $valid; do
             jq -c '{sample: input_filename, checklist: (.axis_evidence | map_values(.checklist)), negative: (.axis_evidence | map_values(.negative))}' "$r" || true
           done
-          coh_c="0"
+          coh_c="0"; coh_kfair="0"
           if [ "$n" -ge 2 ]; then
             COH_BIN="$COH" scripts/cm-consistency.sh llm-spread "$T" $valid || true
-            coh_c=$(python3 -c "import json,sys; print(json.load(open(sys.argv[1]))['coh_consistency'])" ".tsc/cm/consistency/$T.llm.json" 2>/dev/null || echo 0)
+            coh_c=$(jq -r '.coh_consistency_max_pairwise' ".tsc/cm/consistency/$T.llm.json" 2>/dev/null || echo 0)
+            coh_kfair=$(jq -r '.coh_consistency_mean_pairwise' ".tsc/cm/consistency/$T.llm.json" 2>/dev/null || echo 0)
             cp ".tsc/cm/consistency/$T.llm.json" ".tsc/self/consistency-$T.json" 2>/dev/null || true
           fi
-          gate=$(python3 -c "import sys; print('passed' if float(sys.argv[1]) >= 0.9 else 'failed')" "$coh_c")
-          python3 -c "import json,sys; json.dump({'standing_scope': 'house-authored-public-commons', 'admissibility': 'public-only', 'heldout_status': 'none', 'external_anchor_count': 0, 'llm_consistency_gate': sys.argv[4], 'llm_consistency_floor': 0.9, 'coh_consistency': float(sys.argv[3]), 'validated_samples': int(sys.argv[2]), 'target': sys.argv[1]}, open('.tsc/self/standing-' + sys.argv[1] + '.json', 'w'), indent=2)" "$T" "$n" "$coh_c" "$gate"
-          echo "consistency: $T k=$n Coh_consistency=$coh_c gate=$gate (standing gate, never a publishing gate)"
+          # Standing gate: legacy max-pairwise vs the floor (conservative,
+          # unchanged). kfair_experiment_gate: the yield PRECONDITION only —
+          # a short sample set fails the k-fair experiment regardless of
+          # score; the numeric comparison vs baseline happens at close-out.
+          gate=$(awk -v c="$coh_c" 'BEGIN { if (c >= 0.9) print "passed"; else print "failed" }')
+          yield_gate=$([ "$n" -eq "$declared" ] && echo passed || echo failed)
+          jq -n --arg target "$T" --argjson declared "$declared" --argjson n "$n" \
+                --argjson refused "$refused" --argjson stages "$stage_counts" \
+                --argjson coh "$coh_c" --argjson kfair "$coh_kfair" \
+                --arg gate "$gate" --arg ygate "$yield_gate" \
+                '{standing_scope: "house-authored-public-commons", admissibility: "public-only",
+                  heldout_status: "none", external_anchor_count: 0,
+                  llm_consistency_gate: $gate, llm_consistency_floor: 0.9,
+                  coh_consistency: $coh,
+                  coh_consistency_max_pairwise: $coh, coh_consistency_mean_pairwise: $kfair,
+                  declared_samples: $declared, validated_samples: $n,
+                  refused_samples: $refused, refusal_stage_counts: $stages,
+                  kfair_experiment_gate: $ygate, target: $target}' \
+                > ".tsc/self/standing-$T.json"
+          echo "consistency: $T k=$n/$declared Coh_max=$coh_c Coh_kfair=$coh_kfair gate=$gate yield=$yield_gate (standing gate, never a publishing gate)"
 
       - name: Append ledger row and push
         run: |

--- a/.github/workflows/tsc-coherence-ledger.yml
+++ b/.github/workflows/tsc-coherence-ledger.yml
@@ -137,6 +137,7 @@ jobs:
           # files, and the Read tool pages large files — 16 turns starved the
           # repo witness mid-read (run 3).
           RESP=".tsc/self/response/spec.json"; BASE="${RESP%.json}"
+          T="$(basename "$RESP" .json)"
           for i in $(seq 1 3); do
             claude -p "$(cat "$RUNNER_TEMP/witness-prompt.md")" \
               --settings "$RUNNER_TEMP/witness-settings.json" \
@@ -144,12 +145,20 @@ jobs:
               --max-turns 50 || true
             if [ -f "$RESP" ]; then mv "$RESP" "$BASE.r$i.json"; fi
           done
-          # Medoid-of-k adjudication (v3.2.3): the adjudicated response is
-          # the sample nearest the others over the numeric contract fields —
-          # a real witness response, not first-sample order luck. All samples
-          # still feed the consistency spread.
+          # Medoid-of-k adjudication (v3.2.3; funnel-valid election, post-loop
+          # Issue 1): --target makes only samples that pass the COMPLETE
+          # witness funnel electable — the same set the consistency spread is
+          # computed over — so an invalid sample can never be adjudicated into
+          # a guaranteed ingest failure. Zero funnel-valid samples leaves the
+          # canonical response absent: the ingest step skips, and the
+          # consistency step records the explicit no-valid-samples artifact
+          # (expected witness invalidity is DATA, not a pipeline failure).
           if ls "$BASE".r*.json >/dev/null 2>&1; then
-            cp "$("$PWD/engine/ocaml/_build/default/bin/main.exe" witness-medoid "$BASE".r*.json)" "$RESP"
+            if elected="$("$PWD/engine/ocaml/_build/default/bin/main.exe" witness-medoid --target "$T" "$BASE".r*.json)"; then
+              cp "$elected" "$RESP"
+            else
+              echo "witness-medoid: no funnel-valid sample for $T — adjudication withheld"
+            fi
           fi
           ls -l "$(dirname "$RESP")" || true
 
@@ -160,8 +169,15 @@ jobs:
           LLM_PROVIDER: claude-cli
           LLM_MODEL: claude-code-cli@2.1.199
         run: |
-          COH_BIN="$PWD/engine/ocaml/_build/default/bin/main.exe" \
-            scripts/coh-self --ingest spec --output .tsc/self
+          # Same skip-green rule as the measurement route: an absent
+          # response means zero funnel-valid samples, recorded by the
+          # consistency step — not a pipeline failure.
+          if [ -f ".tsc/self/response/spec.json" ]; then
+            COH_BIN="$PWD/engine/ocaml/_build/default/bin/main.exe" \
+              scripts/coh-self --ingest spec --output .tsc/self
+          else
+            echo "no funnel-valid witness samples — ingest skipped"
+          fi
 
       - name: Witness consistency (spec, k=3 spread) and standing scope
         if: ${{ env.CLAUDE_CODE_OAUTH_TOKEN != '' }}
@@ -205,6 +221,18 @@ jobs:
           # score; the numeric comparison vs baseline happens at close-out.
           gate=$(awk -v c="$coh_c" 'BEGIN { if (c >= 0.9) print "passed"; else print "failed" }')
           yield_gate=$([ "$n" -eq "$declared" ] && echo passed || echo failed)
+          # Zero funnel-valid samples: explicit artifact (post-loop Issue 1).
+          # No hybrid report exists, standing below records validated 0 —
+          # expected witness invalidity stays green; only a pipeline failure
+          # (this artifact unwritable) may redden the job.
+          if [ "$n" -eq 0 ]; then
+            jq -n --arg target "$T" --argjson declared "$declared" \
+                  --argjson refused "$refused" --argjson stages "$stage_counts" \
+                  '{target: $target, status: "no_valid_witness_samples",
+                    declared_samples: $declared, validated_samples: 0,
+                    refused_samples: $refused, refusal_stage_counts: $stages}' \
+                  > ".tsc/self/no-valid-witness-samples-$T.json"
+          fi
           jq -n --arg target "$T" --argjson declared "$declared" --argjson n "$n" \
                 --argjson refused "$refused" --argjson stages "$stage_counts" \
                 --argjson coh "$coh_c" --argjson kfair "$coh_kfair" \
@@ -287,6 +315,7 @@ jobs:
           # files, and the Read tool pages large files — 16 turns starved the
           # repo witness mid-read (run 3).
           RESP=".tsc/self/response/engine.json"; BASE="${RESP%.json}"
+          T="$(basename "$RESP" .json)"
           for i in $(seq 1 3); do
             claude -p "$(cat "$RUNNER_TEMP/witness-prompt.md")" \
               --settings "$RUNNER_TEMP/witness-settings.json" \
@@ -294,12 +323,20 @@ jobs:
               --max-turns 50 || true
             if [ -f "$RESP" ]; then mv "$RESP" "$BASE.r$i.json"; fi
           done
-          # Medoid-of-k adjudication (v3.2.3): the adjudicated response is
-          # the sample nearest the others over the numeric contract fields —
-          # a real witness response, not first-sample order luck. All samples
-          # still feed the consistency spread.
+          # Medoid-of-k adjudication (v3.2.3; funnel-valid election, post-loop
+          # Issue 1): --target makes only samples that pass the COMPLETE
+          # witness funnel electable — the same set the consistency spread is
+          # computed over — so an invalid sample can never be adjudicated into
+          # a guaranteed ingest failure. Zero funnel-valid samples leaves the
+          # canonical response absent: the ingest step skips, and the
+          # consistency step records the explicit no-valid-samples artifact
+          # (expected witness invalidity is DATA, not a pipeline failure).
           if ls "$BASE".r*.json >/dev/null 2>&1; then
-            cp "$("$PWD/engine/ocaml/_build/default/bin/main.exe" witness-medoid "$BASE".r*.json)" "$RESP"
+            if elected="$("$PWD/engine/ocaml/_build/default/bin/main.exe" witness-medoid --target "$T" "$BASE".r*.json)"; then
+              cp "$elected" "$RESP"
+            else
+              echo "witness-medoid: no funnel-valid sample for $T — adjudication withheld"
+            fi
           fi
           ls -l "$(dirname "$RESP")" || true
 
@@ -310,8 +347,15 @@ jobs:
           LLM_PROVIDER: claude-cli
           LLM_MODEL: claude-code-cli@2.1.199
         run: |
-          COH_BIN="$PWD/engine/ocaml/_build/default/bin/main.exe" \
-            scripts/coh-self --ingest engine --output .tsc/self
+          # Same skip-green rule as the measurement route: an absent
+          # response means zero funnel-valid samples, recorded by the
+          # consistency step — not a pipeline failure.
+          if [ -f ".tsc/self/response/engine.json" ]; then
+            COH_BIN="$PWD/engine/ocaml/_build/default/bin/main.exe" \
+              scripts/coh-self --ingest engine --output .tsc/self
+          else
+            echo "no funnel-valid witness samples — ingest skipped"
+          fi
 
       - name: Witness consistency (engine, k=3 spread) and standing scope
         if: ${{ env.CLAUDE_CODE_OAUTH_TOKEN != '' }}
@@ -355,6 +399,18 @@ jobs:
           # score; the numeric comparison vs baseline happens at close-out.
           gate=$(awk -v c="$coh_c" 'BEGIN { if (c >= 0.9) print "passed"; else print "failed" }')
           yield_gate=$([ "$n" -eq "$declared" ] && echo passed || echo failed)
+          # Zero funnel-valid samples: explicit artifact (post-loop Issue 1).
+          # No hybrid report exists, standing below records validated 0 —
+          # expected witness invalidity stays green; only a pipeline failure
+          # (this artifact unwritable) may redden the job.
+          if [ "$n" -eq 0 ]; then
+            jq -n --arg target "$T" --argjson declared "$declared" \
+                  --argjson refused "$refused" --argjson stages "$stage_counts" \
+                  '{target: $target, status: "no_valid_witness_samples",
+                    declared_samples: $declared, validated_samples: 0,
+                    refused_samples: $refused, refusal_stage_counts: $stages}' \
+                  > ".tsc/self/no-valid-witness-samples-$T.json"
+          fi
           jq -n --arg target "$T" --argjson declared "$declared" --argjson n "$n" \
                 --argjson refused "$refused" --argjson stages "$stage_counts" \
                 --argjson coh "$coh_c" --argjson kfair "$coh_kfair" \
@@ -437,6 +493,7 @@ jobs:
           # files, and the Read tool pages large files — 16 turns starved the
           # repo witness mid-read (run 3).
           RESP=".tsc/self/response/repo.json"; BASE="${RESP%.json}"
+          T="$(basename "$RESP" .json)"
           for i in $(seq 1 3); do
             claude -p "$(cat "$RUNNER_TEMP/witness-prompt.md")" \
               --settings "$RUNNER_TEMP/witness-settings.json" \
@@ -444,12 +501,20 @@ jobs:
               --max-turns 50 || true
             if [ -f "$RESP" ]; then mv "$RESP" "$BASE.r$i.json"; fi
           done
-          # Medoid-of-k adjudication (v3.2.3): the adjudicated response is
-          # the sample nearest the others over the numeric contract fields —
-          # a real witness response, not first-sample order luck. All samples
-          # still feed the consistency spread.
+          # Medoid-of-k adjudication (v3.2.3; funnel-valid election, post-loop
+          # Issue 1): --target makes only samples that pass the COMPLETE
+          # witness funnel electable — the same set the consistency spread is
+          # computed over — so an invalid sample can never be adjudicated into
+          # a guaranteed ingest failure. Zero funnel-valid samples leaves the
+          # canonical response absent: the ingest step skips, and the
+          # consistency step records the explicit no-valid-samples artifact
+          # (expected witness invalidity is DATA, not a pipeline failure).
           if ls "$BASE".r*.json >/dev/null 2>&1; then
-            cp "$("$PWD/engine/ocaml/_build/default/bin/main.exe" witness-medoid "$BASE".r*.json)" "$RESP"
+            if elected="$("$PWD/engine/ocaml/_build/default/bin/main.exe" witness-medoid --target "$T" "$BASE".r*.json)"; then
+              cp "$elected" "$RESP"
+            else
+              echo "witness-medoid: no funnel-valid sample for $T — adjudication withheld"
+            fi
           fi
           ls -l "$(dirname "$RESP")" || true
 
@@ -460,8 +525,15 @@ jobs:
           LLM_PROVIDER: claude-cli
           LLM_MODEL: claude-code-cli@2.1.199
         run: |
-          COH_BIN="$PWD/engine/ocaml/_build/default/bin/main.exe" \
-            scripts/coh-self --ingest repo --output .tsc/self
+          # Same skip-green rule as the measurement route: an absent
+          # response means zero funnel-valid samples, recorded by the
+          # consistency step — not a pipeline failure.
+          if [ -f ".tsc/self/response/repo.json" ]; then
+            COH_BIN="$PWD/engine/ocaml/_build/default/bin/main.exe" \
+              scripts/coh-self --ingest repo --output .tsc/self
+          else
+            echo "no funnel-valid witness samples — ingest skipped"
+          fi
 
       - name: Witness consistency (repo, k=3 spread) and standing scope
         if: ${{ env.CLAUDE_CODE_OAUTH_TOKEN != '' }}
@@ -505,6 +577,18 @@ jobs:
           # score; the numeric comparison vs baseline happens at close-out.
           gate=$(awk -v c="$coh_c" 'BEGIN { if (c >= 0.9) print "passed"; else print "failed" }')
           yield_gate=$([ "$n" -eq "$declared" ] && echo passed || echo failed)
+          # Zero funnel-valid samples: explicit artifact (post-loop Issue 1).
+          # No hybrid report exists, standing below records validated 0 —
+          # expected witness invalidity stays green; only a pipeline failure
+          # (this artifact unwritable) may redden the job.
+          if [ "$n" -eq 0 ]; then
+            jq -n --arg target "$T" --argjson declared "$declared" \
+                  --argjson refused "$refused" --argjson stages "$stage_counts" \
+                  '{target: $target, status: "no_valid_witness_samples",
+                    declared_samples: $declared, validated_samples: 0,
+                    refused_samples: $refused, refusal_stage_counts: $stages}' \
+                  > ".tsc/self/no-valid-witness-samples-$T.json"
+          fi
           jq -n --arg target "$T" --argjson declared "$declared" --argjson n "$n" \
                 --argjson refused "$refused" --argjson stages "$stage_counts" \
                 --argjson coh "$coh_c" --argjson kfair "$coh_kfair" \

--- a/.github/workflows/tsc-self-measure.yml
+++ b/.github/workflows/tsc-self-measure.yml
@@ -209,6 +209,7 @@ jobs:
           # files, and the Read tool pages large files — 16 turns starved the
           # repo witness mid-read (run 3).
           RESP=".tsc/self/response/${{ matrix.target }}.json"; BASE="${RESP%.json}"
+          T="$(basename "$RESP" .json)"
           for i in $(seq 1 3); do
             claude -p "$(cat "$RUNNER_TEMP/witness-prompt.md")" \
               --settings "$RUNNER_TEMP/witness-settings.json" \
@@ -216,12 +217,20 @@ jobs:
               --max-turns 50 || true
             if [ -f "$RESP" ]; then mv "$RESP" "$BASE.r$i.json"; fi
           done
-          # Medoid-of-k adjudication (v3.2.3): the adjudicated response is
-          # the sample nearest the others over the numeric contract fields —
-          # a real witness response, not first-sample order luck. All samples
-          # still feed the consistency spread.
+          # Medoid-of-k adjudication (v3.2.3; funnel-valid election, post-loop
+          # Issue 1): --target makes only samples that pass the COMPLETE
+          # witness funnel electable — the same set the consistency spread is
+          # computed over — so an invalid sample can never be adjudicated into
+          # a guaranteed ingest failure. Zero funnel-valid samples leaves the
+          # canonical response absent: the ingest step skips, and the
+          # consistency step records the explicit no-valid-samples artifact
+          # (expected witness invalidity is DATA, not a pipeline failure).
           if ls "$BASE".r*.json >/dev/null 2>&1; then
-            cp "$("$PWD/engine/ocaml/_build/default/bin/main.exe" witness-medoid "$BASE".r*.json)" "$RESP"
+            if elected="$("$PWD/engine/ocaml/_build/default/bin/main.exe" witness-medoid --target "$T" "$BASE".r*.json)"; then
+              cp "$elected" "$RESP"
+            else
+              echo "witness-medoid: no funnel-valid sample for $T — adjudication withheld"
+            fi
           fi
           ls -l "$(dirname "$RESP")" || true
 
@@ -230,8 +239,16 @@ jobs:
           LLM_PROVIDER: claude-cli
           LLM_MODEL: claude-code-cli@2.1.199
         run: |
-          COH_BIN="$PWD/engine/ocaml/_build/default/bin/main.exe" \
-            scripts/coh-self --ingest ${{ matrix.target }} --output .tsc/self
+          # Absent response = zero funnel-valid samples (adjudication
+          # withheld upstream). That is witness data, not a pipeline
+          # failure: skip green; the consistency step records the
+          # no-valid-samples artifact and failed standing.
+          if [ -f ".tsc/self/response/${{ matrix.target }}.json" ]; then
+            COH_BIN="$PWD/engine/ocaml/_build/default/bin/main.exe" \
+              scripts/coh-self --ingest ${{ matrix.target }} --output .tsc/self
+          else
+            echo "no funnel-valid witness samples — ingest skipped"
+          fi
 
       # Consistency protocol, LLM arm (cm-of-cms skill section 3): every
       # extra sample is validated through the same witness funnel; the
@@ -279,6 +296,18 @@ jobs:
           # score; the numeric comparison vs baseline happens at close-out.
           gate=$(awk -v c="$coh_c" 'BEGIN { if (c >= 0.9) print "passed"; else print "failed" }')
           yield_gate=$([ "$n" -eq "$declared" ] && echo passed || echo failed)
+          # Zero funnel-valid samples: explicit artifact (post-loop Issue 1).
+          # No hybrid report exists, standing below records validated 0 —
+          # expected witness invalidity stays green; only a pipeline failure
+          # (this artifact unwritable) may redden the job.
+          if [ "$n" -eq 0 ]; then
+            jq -n --arg target "$T" --argjson declared "$declared" \
+                  --argjson refused "$refused" --argjson stages "$stage_counts" \
+                  '{target: $target, status: "no_valid_witness_samples",
+                    declared_samples: $declared, validated_samples: 0,
+                    refused_samples: $refused, refusal_stage_counts: $stages}' \
+                  > ".tsc/self/no-valid-witness-samples-$T.json"
+          fi
           jq -n --arg target "$T" --argjson declared "$declared" --argjson n "$n" \
                 --argjson refused "$refused" --argjson stages "$stage_counts" \
                 --argjson coh "$coh_c" --argjson kfair "$coh_kfair" \

--- a/.github/workflows/tsc-self-measure.yml
+++ b/.github/workflows/tsc-self-measure.yml
@@ -156,7 +156,7 @@ jobs:
           COH_BIN="$PWD/engine/ocaml/_build/default/bin/main.exe" \
             scripts/coh-self --emit-prompt ${{ matrix.target }} --output .tsc/self
 
-      - name: Estimate deltas and evidence (LLM witness — Claude CLI, k=5 samples)
+      - name: Estimate deltas and evidence (LLM witness — Claude CLI, k=3 samples)
         env:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
         run: |
@@ -209,7 +209,7 @@ jobs:
           # files, and the Read tool pages large files — 16 turns starved the
           # repo witness mid-read (run 3).
           RESP=".tsc/self/response/${{ matrix.target }}.json"; BASE="${RESP%.json}"
-          for i in $(seq 1 5); do
+          for i in $(seq 1 3); do
             claude -p "$(cat "$RUNNER_TEMP/witness-prompt.md")" \
               --settings "$RUNNER_TEMP/witness-settings.json" \
               --permission-mode acceptEdits \
@@ -238,7 +238,7 @@ jobs:
       # spread of the validated samples maps through the barrier. The
       # result is a STANDING gate, not a publishing gate — a failing
       # spread never blocks the report, it scopes its standing.
-      - name: Witness consistency (k=5 spread) and standing scope
+      - name: Witness consistency (k=3 spread) and standing scope
         if: always()
         run: |
           T="${{ matrix.target }}"
@@ -254,7 +254,7 @@ jobs:
             fi
           done
           n=$(echo $valid | wc -w)
-          declared=5
+          declared=3
           refused=$((declared - n))
           # Refusal-stage counts from the validation-failure artifacts the
           # funnel wrote for the samples that did not validate.

--- a/.github/workflows/tsc-self-measure.yml
+++ b/.github/workflows/tsc-self-measure.yml
@@ -156,7 +156,7 @@ jobs:
           COH_BIN="$PWD/engine/ocaml/_build/default/bin/main.exe" \
             scripts/coh-self --emit-prompt ${{ matrix.target }} --output .tsc/self
 
-      - name: Estimate deltas and evidence (LLM witness — Claude CLI, k=3 samples)
+      - name: Estimate deltas and evidence (LLM witness — Claude CLI, k=5 samples)
         env:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
         run: |
@@ -209,7 +209,7 @@ jobs:
           # files, and the Read tool pages large files — 16 turns starved the
           # repo witness mid-read (run 3).
           RESP=".tsc/self/response/${{ matrix.target }}.json"; BASE="${RESP%.json}"
-          for i in $(seq 1 3); do
+          for i in $(seq 1 5); do
             claude -p "$(cat "$RUNNER_TEMP/witness-prompt.md")" \
               --settings "$RUNNER_TEMP/witness-settings.json" \
               --permission-mode acceptEdits \
@@ -238,7 +238,7 @@ jobs:
       # spread of the validated samples maps through the barrier. The
       # result is a STANDING gate, not a publishing gate — a failing
       # spread never blocks the report, it scopes its standing.
-      - name: Witness consistency (k=3 spread) and standing scope
+      - name: Witness consistency (k=5 spread) and standing scope
         if: always()
         run: |
           T="${{ matrix.target }}"
@@ -254,21 +254,45 @@ jobs:
             fi
           done
           n=$(echo $valid | wc -w)
+          declared=5
+          refused=$((declared - n))
+          # Refusal-stage counts from the validation-failure artifacts the
+          # funnel wrote for the samples that did not validate.
+          stage_counts=$(cat ".tsc/self"/validate/tsc-$T-*-validation-failure.json 2>/dev/null \
+            | jq -cs 'map(.stage) | group_by(.) | map({(.[0]): length}) | add // {}' 2>/dev/null || echo '{}')
           # Defect-overlap observability: per validated sample, the checklist
           # counts and negative findings, one JSON line each — job logs carry
           # enough to cluster findings across samples without artifact access.
           for r in $valid; do
             jq -c '{sample: input_filename, checklist: (.axis_evidence | map_values(.checklist)), negative: (.axis_evidence | map_values(.negative))}' "$r" || true
           done
-          coh_c="0"
+          coh_c="0"; coh_kfair="0"
           if [ "$n" -ge 2 ]; then
             COH_BIN="$COH" scripts/cm-consistency.sh llm-spread "$T" $valid || true
-            coh_c=$(python3 -c "import json,sys; print(json.load(open(sys.argv[1]))['coh_consistency'])" ".tsc/cm/consistency/$T.llm.json" 2>/dev/null || echo 0)
+            coh_c=$(jq -r '.coh_consistency_max_pairwise' ".tsc/cm/consistency/$T.llm.json" 2>/dev/null || echo 0)
+            coh_kfair=$(jq -r '.coh_consistency_mean_pairwise' ".tsc/cm/consistency/$T.llm.json" 2>/dev/null || echo 0)
             cp ".tsc/cm/consistency/$T.llm.json" ".tsc/self/consistency-$T.json" 2>/dev/null || true
           fi
-          gate=$(python3 -c "import sys; print('passed' if float(sys.argv[1]) >= 0.9 else 'failed')" "$coh_c")
-          python3 -c "import json,sys; json.dump({'standing_scope': 'house-authored-public-commons', 'admissibility': 'public-only', 'heldout_status': 'none', 'external_anchor_count': 0, 'llm_consistency_gate': sys.argv[4], 'llm_consistency_floor': 0.9, 'coh_consistency': float(sys.argv[3]), 'validated_samples': int(sys.argv[2]), 'target': sys.argv[1]}, open('.tsc/self/standing-' + sys.argv[1] + '.json', 'w'), indent=2)" "$T" "$n" "$coh_c" "$gate"
-          echo "consistency: $T k=$n Coh_consistency=$coh_c gate=$gate (standing gate, never a publishing gate)"
+          # Standing gate: legacy max-pairwise vs the floor (conservative,
+          # unchanged). kfair_experiment_gate: the yield PRECONDITION only —
+          # a short sample set fails the k-fair experiment regardless of
+          # score; the numeric comparison vs baseline happens at close-out.
+          gate=$(awk -v c="$coh_c" 'BEGIN { if (c >= 0.9) print "passed"; else print "failed" }')
+          yield_gate=$([ "$n" -eq "$declared" ] && echo passed || echo failed)
+          jq -n --arg target "$T" --argjson declared "$declared" --argjson n "$n" \
+                --argjson refused "$refused" --argjson stages "$stage_counts" \
+                --argjson coh "$coh_c" --argjson kfair "$coh_kfair" \
+                --arg gate "$gate" --arg ygate "$yield_gate" \
+                '{standing_scope: "house-authored-public-commons", admissibility: "public-only",
+                  heldout_status: "none", external_anchor_count: 0,
+                  llm_consistency_gate: $gate, llm_consistency_floor: 0.9,
+                  coh_consistency: $coh,
+                  coh_consistency_max_pairwise: $coh, coh_consistency_mean_pairwise: $kfair,
+                  declared_samples: $declared, validated_samples: $n,
+                  refused_samples: $refused, refusal_stage_counts: $stages,
+                  kfair_experiment_gate: $ygate, target: $target}' \
+                > ".tsc/self/standing-$T.json"
+          echo "consistency: $T k=$n/$declared Coh_max=$coh_c Coh_kfair=$coh_kfair gate=$gate yield=$yield_gate (standing gate, never a publishing gate)"
       - name: Summary
         if: always()
         run: |

--- a/engine/ocaml/bin/main.ml
+++ b/engine/ocaml/bin/main.ml
@@ -22,8 +22,10 @@
     Consistency protocol (skills/cm-of-cms/SKILL.md §3):
       coh consistency-spread --target <t> <resp.json>... [--output <f>]
                                k-sample spread report (lib/consistency.ml)
-      coh witness-medoid <resp.json>...
-                               medoid-of-k adjudication (lib/witness_medoid.ml)
+      coh witness-medoid [--target <t>] <resp.json>...
+                               medoid-of-k adjudication (lib/witness_medoid.ml);
+                               with --target only funnel-valid samples are
+                               candidates and zero valid samples exits 2
 
     External provider route (skills/self-measure/SKILL.md §LLM contract):
       --emit-prompt <path>     write the exact LLM prompt (instruction +
@@ -268,9 +270,10 @@ let () =
    consistency-protocol semantics, in-engine (P1 of the Python-removal
    master issue). Exit codes: 0 success; 2 precondition or malformed
    input. Malformed inputs produce a visible error on stderr, never a
-   silent exclusion (witness-medoid's named compatibility policy —
-   election-side exclusion with first-argument fallback — lives in
-   lib/witness_medoid.ml and is pinned by tests). *)
+   silent exclusion. witness-medoid's two election modes (numeric
+   compatibility mode with first-argument fallback; funnel-valid mode
+   under --target with an explicit zero-valid error) live in
+   lib/witness_medoid.ml and are pinned by tests. *)
 let () =
   if Array.length Sys.argv >= 2 && Sys.argv.(1) = "consistency-spread" then begin
     let target = ref "" and output = ref "" and files = ref [] in
@@ -317,14 +320,33 @@ let () =
 
 let () =
   if Array.length Sys.argv >= 2 && Sys.argv.(1) = "witness-medoid" then begin
-    let files =
-      Array.to_list (Array.sub Sys.argv 2 (Array.length Sys.argv - 2))
+    let target = ref "" and files = ref [] in
+    let rec eat i =
+      if i >= Array.length Sys.argv then ()
+      else match Sys.argv.(i) with
+        | "--target" when i + 1 < Array.length Sys.argv ->
+          target := Sys.argv.(i + 1); eat (i + 2)
+        | f -> files := f :: !files; eat (i + 1)
     in
-    match Tsc_engine.Witness_medoid.choose files with
+    eat 2;
+    let files = List.rev !files in
+    (* With --target the election is funnel-aware: only samples that
+       pass the complete witness-validation funnel are candidates, and
+       zero valid samples is an explicit exit 2 (the workflow records a
+       no-valid-samples artifact instead of adjudicating an invalid
+       sample into a guaranteed ingest failure). Without --target the
+       legacy numeric-completeness election applies. *)
+    let result =
+      if !target <> "" then
+        Tsc_engine.Witness_medoid.choose_valid ~expected_target:!target files
+      else Tsc_engine.Witness_medoid.choose files
+    in
+    match result with
     | Ok path -> print_endline path; exit 0
     | Error e ->
       Printf.eprintf "coh witness-medoid: %s\n" e;
-      prerr_endline "usage: coh witness-medoid <response.json>...";
+      prerr_endline
+        "usage: coh witness-medoid [--target <target>] <response.json>...";
       exit 2
   end
 

--- a/engine/ocaml/lib/consistency.ml
+++ b/engine/ocaml/lib/consistency.ml
@@ -49,14 +49,27 @@ let llm_spread_report ~target ~files : (Yojson.Safe.t, string) result =
     | Error e -> Error e
     | Ok vectors ->
       let per_field = Witness_numeric.per_field_spread vectors in
+      let mean_pairwise = Witness_numeric.per_field_mean_pairwise vectors in
       let delta = Witness_numeric.max_spread vectors in
       let coh = coh_from_delta delta in
+      (* k-fair companion (Issue D): mean-pairwise per field, then max
+         across fields; same barrier, same lambda. Reported under NEW
+         names — the legacy max-pairwise fields stay untouched for
+         history continuity and remain the conservative standing
+         metric unless separately promoted. *)
+      let delta_kfair = Witness_numeric.max_mean_pairwise vectors in
+      let coh_kfair = coh_from_delta delta_kfair in
       let fields_json =
         `Assoc (List.map (fun (f, vals, spread) ->
+          let mean =
+            match List.assoc_opt f mean_pairwise with
+            | Some d -> d | None -> 0.0
+          in
           (Witness_numeric.field_name f,
            `Assoc [
              ("values", `List (List.map (fun x -> `Float x) vals));
              ("spread", `Float (round6 spread));
+             ("mean_pairwise", `Float (round6 mean));
            ]))
           per_field)
       in
@@ -68,5 +81,13 @@ let llm_spread_report ~target ~files : (Yojson.Safe.t, string) result =
         ("fields", fields_json);
         ("delta_consistency", `Float (round6 delta));
         ("coh_consistency", `Float (round6 coh));
+        ("delta_consistency_max_pairwise", `Float (round6 delta));
+        ("coh_consistency_max_pairwise", `Float (round6 coh));
+        ("delta_consistency_mean_pairwise", `Float (round6 delta_kfair));
+        ("coh_consistency_mean_pairwise", `Float (round6 coh_kfair));
+        ("statistic", `Assoc [
+          ("legacy", `String "max_pairwise");
+          ("kfair", `String "mean_pairwise");
+        ]);
         ("protocol", `String "skills/cm-of-cms/SKILL.md section 3");
       ])

--- a/engine/ocaml/lib/report.ml
+++ b/engine/ocaml/lib/report.ml
@@ -141,6 +141,18 @@ let to_json ~result ~metadata ?(mode = "llm")
         ("beta", evidence_to_yojson result.result_beta_evidence);
         ("gamma", evidence_to_yojson result.result_gamma_evidence);
       ]);
+      ("defect_cards",
+        `List (List.map (fun c ->
+          `Assoc [
+            ("id", `String c.card_id);
+            ("primary_axis", `String c.card_primary_axis);
+            ("category", `String c.card_category);
+            ("severity", `String c.card_severity);
+            ("evidence", `String c.card_evidence);
+            ("summary", `String c.card_summary);
+            ("secondary_axes",
+              `List (List.map (fun s -> `String s) c.card_secondary_axes));
+          ]) result.result_defect_cards));
       ("defect_summary", defect_summary_to_yojson result);
       ("unresolved_ambiguity",
         `List (List.map (fun s -> `String s) result.result_unresolved_ambiguity));

--- a/engine/ocaml/lib/response_schema.ml
+++ b/engine/ocaml/lib/response_schema.ml
@@ -73,6 +73,52 @@ let get_checklist sub =
      | Some _ -> Error "field 'checklist' is not an object")
   | _ -> Error "expected JSON object"
 
+(** Parse the optional defect_cards array (v3.2.4). Absent -> Ok []
+    (base schema tolerates pre-v3.2.4 shapes; the funnel's defect_cards
+    stage refuses absence). Present but structurally malformed
+    (non-array, non-object card, missing/mistyped required field)
+    -> Error. Semantic checks (uniqueness, axis/category validity,
+    checklist reconciliation) belong to the funnel stage. *)
+let get_defect_cards json =
+  match json with
+  | `Assoc fields ->
+    (match List.assoc_opt "defect_cards" fields with
+     | None -> Ok []
+     | Some (`List items) ->
+       let str card k =
+         match List.assoc_opt k card with
+         | Some (`String s) when String.length s > 0 -> Ok s
+         | Some _ -> Error (Printf.sprintf "card field '%s' must be a non-empty string" k)
+         | None -> Error (Printf.sprintf "card missing field '%s'" k)
+       in
+       let rec collect acc = function
+         | [] -> Ok (List.rev acc)
+         | `Assoc card :: rest ->
+           (match str card "id", str card "primary_axis",
+                  str card "category", str card "severity",
+                  str card "evidence", str card "summary" with
+            | Ok id, Ok ax, Ok cat, Ok sev, Ok ev, Ok su ->
+              let secondary =
+                match List.assoc_opt "secondary_axes" card with
+                | Some (`List xs) ->
+                  List.filter_map
+                    (function `String s -> Some s | _ -> None) xs
+                | _ -> []
+              in
+              collect ({ card_id = id; card_primary_axis = ax;
+                         card_category = cat; card_severity = sev;
+                         card_evidence = ev; card_summary = su;
+                         card_secondary_axes = secondary } :: acc) rest
+            | Error e, _, _, _, _, _ | _, Error e, _, _, _, _
+            | _, _, Error e, _, _, _ | _, _, _, Error e, _, _
+            | _, _, _, _, Error e, _ | _, _, _, _, _, Error e ->
+              Error e)
+         | _ :: _ -> Error "defect_cards items must be objects"
+       in
+       collect [] items
+     | Some _ -> Error "field 'defect_cards' is not an array")
+  | _ -> Error "expected JSON object"
+
 (** Extract axis_evidence from a JSON sub-object. *)
 let get_axis_evidence key json =
   match json with
@@ -165,12 +211,13 @@ let validate_result json =
     get_axis_evidence "beta" axis_evidence_obj,
     get_axis_evidence "gamma" axis_evidence_obj,
     get_string_list "unresolved_ambiguity" json,
-    get_fixes "next_fixes" json
+    get_fixes "next_fixes" json,
+    get_defect_cards json
   with
   | Ok target, Ok alpha, Ok beta, Ok gamma,
     Ok bottleneck, Ok confidence, Ok summary,
     Ok alpha_ev, Ok beta_ev, Ok gamma_ev,
-    Ok ambiguity, Ok fixes ->
+    Ok ambiguity, Ok fixes, Ok cards ->
     (match validate_score "alpha" alpha,
            validate_score "beta" beta,
            validate_score "gamma" gamma,
@@ -189,21 +236,23 @@ let validate_result json =
          result_gamma_evidence = gamma_ev;
          result_unresolved_ambiguity = ambiguity;
          result_next_fixes = fixes;
+         result_defect_cards = cards;
        }
      | Error e, _, _, _ | _, Error e, _, _
      | _, _, Error e, _ | _, _, _, Error e -> Error e)
-  | Error e, _, _, _, _, _, _, _, _, _, _, _
-  | _, Error e, _, _, _, _, _, _, _, _, _, _
-  | _, _, Error e, _, _, _, _, _, _, _, _, _
-  | _, _, _, Error e, _, _, _, _, _, _, _, _
-  | _, _, _, _, Error e, _, _, _, _, _, _, _
-  | _, _, _, _, _, Error e, _, _, _, _, _, _
-  | _, _, _, _, _, _, Error e, _, _, _, _, _
-  | _, _, _, _, _, _, _, Error e, _, _, _, _
-  | _, _, _, _, _, _, _, _, Error e, _, _, _
-  | _, _, _, _, _, _, _, _, _, Error e, _, _
-  | _, _, _, _, _, _, _, _, _, _, Error e, _
-  | _, _, _, _, _, _, _, _, _, _, _, Error e -> Error e
+  | Error e, _, _, _, _, _, _, _, _, _, _, _, _
+  | _, Error e, _, _, _, _, _, _, _, _, _, _, _
+  | _, _, Error e, _, _, _, _, _, _, _, _, _, _
+  | _, _, _, Error e, _, _, _, _, _, _, _, _, _
+  | _, _, _, _, Error e, _, _, _, _, _, _, _, _
+  | _, _, _, _, _, Error e, _, _, _, _, _, _, _
+  | _, _, _, _, _, _, Error e, _, _, _, _, _, _
+  | _, _, _, _, _, _, _, Error e, _, _, _, _, _
+  | _, _, _, _, _, _, _, _, Error e, _, _, _, _
+  | _, _, _, _, _, _, _, _, _, Error e, _, _, _
+  | _, _, _, _, _, _, _, _, _, _, Error e, _, _
+  | _, _, _, _, _, _, _, _, _, _, _, Error e, _
+  | _, _, _, _, _, _, _, _, _, _, _, _, Error e -> Error e
 
 (** Extract per-pair delta values from a v3.2.0 LLM response.
     Returns (delta_alpha_beta, delta_beta_gamma, delta_gamma_alpha) — each
@@ -314,10 +363,14 @@ let validate_v32_deltas json =
     - [`V32_delta]         strict v3.2 delta validation failed
     - [`Checklist]         v3.2.3 per-axis defect walk missing or malformed
                            (wrong category set, bad severity, none/count
-                           inconsistency) *)
+                           inconsistency)
+    - [`Defect_cards]      v3.2.4 structured defect cards missing,
+                           malformed, or inconsistent with the checklist
+                           (duplicate id, category not of the primary
+                           axis, count/severity reconciliation failed) *)
 type witness_failure_stage =
   [ `Parse | `Base_schema | `Prohibited_fields | `Target_mismatch
-  | `V32_delta | `Checklist ]
+  | `V32_delta | `Checklist | `Defect_cards ]
 
 type witness_failure = {
   wf_stage : witness_failure_stage;
@@ -334,6 +387,7 @@ let witness_stage_to_string = function
   | `Target_mismatch   -> "target_mismatch"
   | `V32_delta         -> "v3_2_delta"
   | `Checklist         -> "checklist"
+  | `Defect_cards      -> "defect_cards"
 
 (* ------------------------------------------------------------------ *)
 (* v3.2.3 per-axis defect checklist (runtime/SELF-MEASURE.md §3.2)    *)
@@ -393,6 +447,90 @@ let validate_axis_checklist axis (checklist : (string * (int * string)) list) =
       else Hashtbl.add seen cat ()
     ) checklist
   end;
+  List.rev !errors
+
+(* ------------------------------------------------------------------ *)
+(* v3.2.4 defect cards (runtime/SELF-MEASURE.md §3.2/§7)              *)
+(* ------------------------------------------------------------------ *)
+
+let card_severities = [ "cosmetic"; "isolated"; "systemic" ]
+
+let severity_rank = function
+  | "cosmetic" -> 1 | "isolated" -> 2 | "systemic" -> 3 | _ -> 0
+
+(** Validate the defect-card surface against the instruction's rules
+    AND reconcile it with the per-axis checklist: the checklist is the
+    per-category aggregate VIEW of the cards, and the two must agree.
+    Returns human-readable errors (empty = valid). *)
+let validate_result_defect_cards result =
+  let errors = ref [] in
+  let err fmt = Printf.ksprintf (fun s -> errors := s :: !errors) fmt in
+  let cards = result.result_defect_cards in
+  let axes = [ ("alpha", result.result_alpha_evidence);
+               ("beta", result.result_beta_evidence);
+               ("gamma", result.result_gamma_evidence) ] in
+  let total_checklist_defects =
+    List.fold_left (fun acc (_, ev) ->
+      List.fold_left (fun a (_, (c, _)) -> a + c) acc
+        ev.evidence_checklist) 0 axes
+  in
+  if cards = [] && total_checklist_defects > 0 then
+    err "defect_cards missing while the checklist counts %d defect(s) —          the v3.2.4 card surface is required" total_checklist_defects;
+  (* Per-card shape rules. *)
+  let seen_ids = Hashtbl.create 16 in
+  let seen_content = Hashtbl.create 16 in
+  List.iter (fun c ->
+    if Hashtbl.mem seen_ids c.card_id then
+      err "duplicate defect card id '%s'" c.card_id
+    else Hashtbl.add seen_ids c.card_id ();
+    (* One defect, one primary axis: identical evidence+summary under
+       two different primary axes is the same defect filed twice. *)
+    let content_key = c.card_evidence ^ "\x00" ^ c.card_summary in
+    (match Hashtbl.find_opt seen_content content_key with
+     | Some other_axis when other_axis <> c.card_primary_axis ->
+       err "card '%s' duplicates a defect already filed under primary             axis '%s' — a defect has exactly one primary axis"
+         c.card_id other_axis
+     | _ -> Hashtbl.replace seen_content content_key c.card_primary_axis);
+    if not (List.mem c.card_primary_axis [ "alpha"; "beta"; "gamma" ]) then
+      err "card '%s': unknown primary_axis '%s'" c.card_id c.card_primary_axis
+    else if not (List.mem c.card_category
+                   (checklist_categories c.card_primary_axis)) then
+      err "card '%s': category '%s' is not a %s-axis checklist category"
+        c.card_id c.card_category c.card_primary_axis;
+    if not (List.mem c.card_severity card_severities) then
+      err "card '%s': severity '%s' invalid (no 'none' cards — a card IS            a defect)" c.card_id c.card_severity;
+    List.iter (fun sa ->
+      if not (List.mem sa [ "alpha"; "beta"; "gamma" ]) then
+        err "card '%s': unknown secondary axis '%s'" c.card_id sa;
+      if sa = c.card_primary_axis then
+        err "card '%s': primary axis repeated in secondary_axes" c.card_id)
+      c.card_secondary_axes
+  ) cards;
+  (* Reconciliation: checklist (axis, category) count == card count;
+     checklist worst severity == worst card severity; none iff zero. *)
+  List.iter (fun (axis, ev) ->
+    List.iter (fun (cat, (count, severity)) ->
+      let matching =
+        List.filter (fun c ->
+          c.card_primary_axis = axis && c.card_category = cat) cards
+      in
+      let n = List.length matching in
+      if n <> count then
+        err "%s/%s: checklist count %d but %d defect card(s)"
+          axis cat count n;
+      if n > 0 then begin
+        let worst =
+          List.fold_left (fun acc c ->
+            if severity_rank c.card_severity > severity_rank acc
+            then c.card_severity else acc)
+            "cosmetic" matching
+        in
+        if severity <> worst then
+          err "%s/%s: checklist severity '%s' but worst card severity '%s'"
+            axis cat severity worst
+      end
+    ) ev.evidence_checklist
+  ) axes;
   List.rev !errors
 
 (** Validate the full three-axis walk on a parsed result. *)
@@ -461,8 +599,12 @@ let validate_witness_response ~expected_target raw =
                      [])
           | Ok deltas ->
             match validate_result_checklists result with
-            | [] -> Ok (result, deltas)
-            | errors -> Error (witness_failure `Checklist errors)
+            | errors when errors <> [] ->
+              Error (witness_failure `Checklist errors)
+            | _ ->
+              match validate_result_defect_cards result with
+              | [] -> Ok (result, deltas)
+              | errors -> Error (witness_failure `Defect_cards errors)
 
 (** Render a witness failure as a single-line human string (stderr). *)
 let format_witness_failure wf =

--- a/engine/ocaml/lib/response_schema.ml
+++ b/engine/ocaml/lib/response_schema.ml
@@ -475,7 +475,8 @@ let validate_result_defect_cards result =
         ev.evidence_checklist) 0 axes
   in
   if cards = [] && total_checklist_defects > 0 then
-    err "defect_cards missing while the checklist counts %d defect(s) —          the v3.2.4 card surface is required" total_checklist_defects;
+    err "defect_cards missing while the checklist counts %d defect(s) — \
+         the v3.2.4 card surface is required" total_checklist_defects;
   (* Per-card shape rules. *)
   let seen_ids = Hashtbl.create 16 in
   let seen_content = Hashtbl.create 16 in
@@ -488,7 +489,8 @@ let validate_result_defect_cards result =
     let content_key = c.card_evidence ^ "\x00" ^ c.card_summary in
     (match Hashtbl.find_opt seen_content content_key with
      | Some other_axis when other_axis <> c.card_primary_axis ->
-       err "card '%s' duplicates a defect already filed under primary             axis '%s' — a defect has exactly one primary axis"
+       err "card '%s' duplicates a defect already filed under primary \
+            axis '%s' — a defect has exactly one primary axis"
          c.card_id other_axis
      | _ -> Hashtbl.replace seen_content content_key c.card_primary_axis);
     if not (List.mem c.card_primary_axis [ "alpha"; "beta"; "gamma" ]) then
@@ -498,7 +500,8 @@ let validate_result_defect_cards result =
       err "card '%s': category '%s' is not a %s-axis checklist category"
         c.card_id c.card_category c.card_primary_axis;
     if not (List.mem c.card_severity card_severities) then
-      err "card '%s': severity '%s' invalid (no 'none' cards — a card IS            a defect)" c.card_id c.card_severity;
+      err "card '%s': severity '%s' invalid (no 'none' cards — a card \
+           IS a defect)" c.card_id c.card_severity;
     List.iter (fun sa ->
       if not (List.mem sa [ "alpha"; "beta"; "gamma" ]) then
         err "card '%s': unknown secondary axis '%s'" c.card_id sa;

--- a/engine/ocaml/lib/types.ml
+++ b/engine/ocaml/lib/types.ml
@@ -65,6 +65,21 @@ type axis_evidence = {
   evidence_checklist : (string * (int * string)) list;
 }
 
+(** A structured defect card (SELF-MEASURE v3.2.4): the canonical
+    machine-readable defect surface. Every defect is filed under
+    EXACTLY ONE primary axis by the instruction's precedence rule;
+    other plausible axes are secondary. axis_evidence.negative remains
+    the human-readable projection. *)
+type defect_card = {
+  card_id : string;
+  card_primary_axis : string;           (* alpha | beta | gamma *)
+  card_category : string;               (* a category of that axis *)
+  card_severity : string;               (* cosmetic|isolated|systemic *)
+  card_evidence : string;               (* path:line or section citation *)
+  card_summary : string;
+  card_secondary_axes : string list;
+}
+
 (** A suggested fix. *)
 type suggested_fix = {
   fix_axis : string;
@@ -85,6 +100,7 @@ type measure_result = {
   result_gamma_evidence : axis_evidence;
   result_unresolved_ambiguity : string list;
   result_next_fixes : suggested_fix list;
+  result_defect_cards : defect_card list;
 }
 
 (** Run metadata for reproducibility. *)

--- a/engine/ocaml/lib/types.ml
+++ b/engine/ocaml/lib/types.ml
@@ -120,4 +120,4 @@ type run_metadata = {
     Distinct from the REPORT schema version (report.ml, "v3.2.0"): that
     names the shape of emitted report JSON, which did not change across
     witness-protocol revisions. *)
-let self_measure_protocol_version = "SELF-MEASURE/3.2.3"
+let self_measure_protocol_version = "SELF-MEASURE/3.2.4"

--- a/engine/ocaml/lib/witness_medoid.ml
+++ b/engine/ocaml/lib/witness_medoid.ml
@@ -8,45 +8,102 @@
     no longer first-sample order luck. Adjudication never changes the
     spread — all samples still feed the consistency report.
 
-    Compatibility policy (named, deliberate — inherited from the
-    retired scripts/witness-medoid.py and pinned by tests):
-    - samples that fail to parse or lack a numeric field are EXCLUDED
-      from the election (the funnel refuses them downstream anyway);
-    - if no sample parses, the FIRST argument is chosen (the ingest
-      step then refuses it with a recorded artifact — same failure
-      surface as before the medoid existed);
-    - ties break toward the earliest argument. *)
+    Two election modes, one election:
 
-(** Path of the medoid sample. [Error] only on an empty input list. *)
+    - [choose] filters on NUMERIC completeness only. Compatibility
+      policy (named, deliberate — inherited from the retired
+      scripts/witness-medoid.py and pinned by tests): unparseable or
+      field-incomplete samples are excluded; if no sample parses, the
+      FIRST argument is chosen (the ingest step then refuses it with a
+      recorded artifact); ties break toward the earliest argument.
+
+    - [choose_valid] filters on FULL FUNNEL validity
+      (Response_schema.validate_witness_response — every refusal stage,
+      not just numeric shape). A numerically complete sample that fails
+      the checklist or defect-card stages can never be adjudicated
+      (post-loop stabilization Issue 1: under [choose] such a sample
+      could be elected and then hard-fail the ingest step). No
+      first-argument fallback: zero funnel-valid samples is an explicit
+      [Error], so the caller records a no-valid-samples artifact
+      instead of manufacturing an ingest failure. *)
+
+(** Elect the medoid among [(path, vector)] candidates.
+    Ties break toward the earliest element. None on empty input. *)
+let elect (candidates : (string * Witness_numeric.vector) list)
+  : string option =
+  match candidates with
+  | [] -> None
+  | [ (p, _) ] -> Some p
+  | _ ->
+    let indexed = List.mapi (fun i (p, v) -> (i, p, v)) candidates in
+    let best =
+      List.fold_left (fun acc (i, p, v) ->
+        let total =
+          List.fold_left (fun t (j, _, w) ->
+            if i = j then t
+            else t +. Witness_numeric.l1_distance v w)
+            0.0 indexed
+        in
+        match acc with
+        | Some (_, best_total) when best_total <= total -> acc
+        | _ -> Some (p, total))
+        None indexed
+    in
+    Option.map fst best
+
+(** Path of the medoid sample over numerically complete candidates.
+    [Error] only on an empty input list. *)
 let choose (paths : string list) : (string, string) result =
   match paths with
   | [] -> Error "witness-medoid needs at least one response file"
   | first :: _ ->
-    let valid =
+    let candidates =
       List.filter_map (fun p ->
         match Witness_numeric.of_json_file p with
         | Ok v -> Some (p, v)
         | Error _ -> None)
         paths
     in
-    (match valid with
-     | [] -> Ok first
-     | [ (p, _) ] -> Ok p
-     | _ ->
-       let indexed = List.mapi (fun i (p, v) -> (i, p, v)) valid in
-       let best =
-         List.fold_left (fun acc (i, p, v) ->
-           let total =
-             List.fold_left (fun t (j, _, w) ->
-               if i = j then t
-               else t +. Witness_numeric.l1_distance v w)
-               0.0 indexed
-           in
-           match acc with
-           | Some (_, best_total) when best_total <= total -> acc
-           | _ -> Some (p, total))
-           None indexed
-       in
-       (match best with
-        | Some (p, _) -> Ok p
-        | None -> Ok first))
+    (match elect candidates with
+     | Some p -> Ok p
+     | None -> Ok first)
+
+(** Path of the medoid sample over FUNNEL-VALID candidates: each file
+    must pass the complete witness-validation funnel for
+    [expected_target]. [Error] when the input list is empty or no
+    sample validates — never a fallback to an invalid sample. *)
+let choose_valid ~(expected_target : string) (paths : string list)
+  : (string, string) result =
+  match paths with
+  | [] -> Error "witness-medoid needs at least one response file"
+  | _ ->
+    let candidates =
+      List.filter_map (fun p ->
+        let raw =
+          try
+            let ic = open_in_bin p in
+            let n = in_channel_length ic in
+            let s = really_input_string ic n in
+            close_in ic; Some s
+          with _ -> None
+        in
+        match raw with
+        | None -> None
+        | Some raw ->
+          (match Response_schema.validate_witness_response
+                   ~expected_target raw with
+           | Ok _ ->
+             (match Witness_numeric.of_json_file p with
+              | Ok v -> Some (p, v)
+              | Error _ -> None)
+           | Error _ -> None))
+        paths
+    in
+    (match elect candidates with
+     | Some p -> Ok p
+     | None ->
+       Error
+         (Printf.sprintf
+            "no funnel-valid witness sample among %d file(s) for \
+             target '%s'"
+            (List.length paths) expected_target))

--- a/engine/ocaml/lib/witness_numeric.ml
+++ b/engine/ocaml/lib/witness_numeric.ml
@@ -98,3 +98,31 @@ let per_field_spread (vs : vector list) : (field * float list * float) list =
 let max_spread (vs : vector list) : float =
   List.fold_left (fun acc (_, _, s) -> Float.max acc s)
     0.0 (per_field_spread vs)
+
+(** Per-field MEAN absolute pairwise difference — the k-fair companion
+    statistic (Issue D): unlike the max, the mean of all m(m-1)/2
+    pairwise differences does not grow monotonically with sample count,
+    so k=3 and k=5 readings are comparable. Returns entries in
+    [all_fields] order. Requires >= 2 vectors (0.0 per field otherwise
+    is never emitted — callers enforce the arity upstream). *)
+let per_field_mean_pairwise (vs : vector list) : (field * float) list =
+  List.mapi (fun i f ->
+    let vals = List.map (fun v -> v.(i)) vs in
+    let total = ref 0.0 and pairs = ref 0 in
+    let rec walk = function
+      | [] -> ()
+      | a :: rest ->
+        List.iter (fun b ->
+          total := !total +. Float.abs (a -. b);
+          incr pairs) rest;
+        walk rest
+    in
+    walk vals;
+    (f, if !pairs = 0 then 0.0 else !total /. Float.of_int !pairs)
+  ) all_fields
+
+(** The k-fair consistency delta: max over fields of the per-field
+    mean pairwise difference. *)
+let max_mean_pairwise (vs : vector list) : float =
+  List.fold_left (fun acc (_, d) -> Float.max acc d)
+    0.0 (per_field_mean_pairwise vs)

--- a/engine/ocaml/test/test_consistency.ml
+++ b/engine/ocaml/test/test_consistency.ml
@@ -163,6 +163,53 @@ let test_spread_report () =
      | _ -> fail "spread: fields object missing")
   | Ok _ -> fail "spread: report is not an object"
 
+(* k-fair companion statistic (Issue D): mean absolute pairwise
+   difference per field, max across fields; legacy max-pairwise fields
+   unchanged; both routed through the same barrier. *)
+let test_kfair_statistic () =
+  let r1 = write_response "k1.json" [ ("alpha", 0.62) ] in
+  let r2 = write_response "k2.json" [ ("alpha", 0.66) ] in
+  let r3 = write_response "k3.json" [ ("alpha", 0.87) ] in
+  (* pairwise |diffs| on alpha: 0.04, 0.25, 0.21 -> mean 0.5/3 *)
+  let expected_mean = (0.04 +. 0.25 +. 0.21) /. 3.0 in
+  (match Consistency.llm_spread_report ~target:"spec" ~files:[ r1; r2; r3 ] with
+   | Ok (`Assoc kv) ->
+     let num k = match List.assoc_opt k kv with
+       | Some (`Float x) -> x | _ -> nan in
+     check_close ~tol:1e-6 "kfair: delta_consistency_mean_pairwise"
+       (num "delta_consistency_mean_pairwise") expected_mean;
+     check_close ~tol:1e-6 "kfair: coh via the same canonical barrier"
+       (num "coh_consistency_mean_pairwise")
+       (Coherence.coherence_link ~lambda:1.0
+          ~delta:(Float.round (expected_mean *. 1e6) /. 1e6));
+     check (num "delta_consistency_max_pairwise" = num "delta_consistency"
+            && num "coh_consistency_max_pairwise" = num "coh_consistency")
+       "kfair: legacy fields preserved verbatim under both names";
+     check_close ~tol:1e-9 "kfair: legacy max-pairwise still 0.25"
+       (num "delta_consistency") 0.25;
+     (match List.assoc_opt "statistic" kv with
+      | Some (`Assoc st) ->
+        check (List.assoc_opt "legacy" st = Some (`String "max_pairwise")
+               && List.assoc_opt "kfair" st = Some (`String "mean_pairwise"))
+          "kfair: statistic labels present"
+      | _ -> fail "kfair: statistic block missing")
+   | Ok _ -> fail "kfair: report not an object"
+   | Error e -> fail ("kfair: report errored: " ^ e));
+  (* k-fairness itself: duplicating an agreeing sample LOWERS the mean
+     statistic while the max stays put — more agreeing samples must
+     never read as worse. *)
+  let r4 = write_response "k4.json" [ ("alpha", 0.66) ] in
+  match Consistency.llm_spread_report ~target:"spec"
+          ~files:[ r1; r2; r3; r4 ] with
+  | Ok (`Assoc kv) ->
+    let num k = match List.assoc_opt k kv with
+      | Some (`Float x) -> x | _ -> nan in
+    check (num "delta_consistency_max_pairwise" = 0.25)
+      "kfair: max-pairwise unchanged by an agreeing 4th sample";
+    check (num "delta_consistency_mean_pairwise" < expected_mean)
+      "kfair: mean-pairwise falls with an agreeing 4th sample"
+  | _ -> fail "kfair: 4-sample report failed"
+
 let test_spread_refusals () =
   let r1 = write_response "one.json" [] in
   (match Consistency.llm_spread_report ~target:"spec" ~files:[ r1 ] with
@@ -248,6 +295,7 @@ let () =
   Printf.printf "=== TSC consistency + medoid tests (Python-removal P1) ===\n%!";
   test_barrier ();
   test_spread_report ();
+  test_kfair_statistic ();
   test_spread_refusals ();
   test_medoid ();
   test_protocol_version_pin ();

--- a/engine/ocaml/test/test_mechanical.ml
+++ b/engine/ocaml/test/test_mechanical.ml
@@ -248,6 +248,7 @@ let test_hybrid_json_schema () =
     result_gamma_evidence = { evidence_positive = ["good g"]; evidence_negative = []; evidence_reason = "test"; evidence_checklist = [] };
     result_unresolved_ambiguity = [];
     result_next_fixes = [];
+    result_defect_cards = [];
   } in
   let mech_result = Mechanical_scoring.score_files sample_files in
   let hybrid = Hybrid_scoring.combine ~target:"test" mech_result llm_result in
@@ -298,6 +299,7 @@ let test_hybrid_preserves_both () =
     result_beta_evidence  = { evidence_positive = []; evidence_negative = []; evidence_reason = ""; evidence_checklist = [] };
     result_gamma_evidence = { evidence_positive = []; evidence_negative = []; evidence_reason = ""; evidence_checklist = [] };
     result_unresolved_ambiguity = []; result_next_fixes = [];
+    result_defect_cards = [];
   } in
   let mech_result = Mechanical_scoring.score_files sample_files in
   let hybrid = Hybrid_scoring.combine ~target:"test" mech_result llm_result in
@@ -426,6 +428,7 @@ let test_hybrid_aggregate_uses_coherence_helper () =
     result_beta_evidence  = { evidence_positive = []; evidence_negative = []; evidence_reason = ""; evidence_checklist = [] };
     result_gamma_evidence = { evidence_positive = []; evidence_negative = []; evidence_reason = ""; evidence_checklist = [] };
     result_unresolved_ambiguity = []; result_next_fixes = [];
+    result_defect_cards = [];
   } in
   let mech_result = Mechanical_scoring.score_files sample_files in
   let hybrid = Hybrid_scoring.combine ~target:"test" mech_result llm_result in

--- a/engine/ocaml/test/test_response_schema.ml
+++ b/engine/ocaml/test/test_response_schema.ml
@@ -395,6 +395,69 @@ let test_funnel_delta_failure_classified () =
       "funnel negative: out-of-range delta classified as v3_2_delta with field named"
 
 (* ------------------------------------------------------------------ *)
+(* Funnel-valid medoid election (post-loop stabilization Issue 1).
+   A sample can be NUMERICALLY complete yet funnel-invalid (e.g. a
+   duplicate defect-card id): Witness_medoid.choose_valid must never
+   elect it, and zero funnel-valid samples must be an explicit Error,
+   never a fallback to an invalid sample. *)
+
+let write_tmp name content =
+  let path = Filename.concat (Filename.get_temp_dir_name ()) name in
+  let oc = open_out path in
+  output_string oc content; close_out oc; path
+
+let numerically_complete_invalid_raw =
+  (* duplicate card id — refused at the defect_cards stage, but every
+     numeric contract field is present and parseable *)
+  witness_raw
+    ~defect_cards:{|[
+      {"id": "D1", "primary_axis": "beta", "category": "broken-reference",
+       "severity": "isolated", "evidence": "f:1", "summary": "ref one"},
+      {"id": "D1", "primary_axis": "beta", "category": "broken-reference",
+       "severity": "cosmetic", "evidence": "f:2", "summary": "ref two"},
+      {"id": "D3", "primary_axis": "beta", "category": "fact-drift",
+       "severity": "cosmetic", "evidence": "f:3", "summary": "drift"}
+    ]|}
+    ~beta_checklist:nonzero_beta_checklist ()
+
+let test_medoid_choose_valid_excludes_funnel_invalid () =
+  let invalid = write_tmp "cv_invalid.json" numerically_complete_invalid_raw in
+  (* Sanity: the invalid sample IS numerically complete — the legacy
+     numeric election alone would consider it. *)
+  (match Witness_numeric.of_json_file invalid with
+   | Ok _ -> pass "choose_valid setup: invalid sample is numerically complete"
+   | Error e -> fail ("choose_valid setup: invalid sample not numeric: " ^ e));
+  let valid1 = write_tmp "cv_valid1.json" (witness_raw ()) in
+  let valid2 = write_tmp "cv_valid2.json" (witness_raw ~delta_ab:"0.12" ()) in
+  (* Positive: election runs over the funnel-valid pair only; the
+     invalid sample is listed first and must never win. *)
+  (match Witness_medoid.choose_valid ~expected_target:"spec"
+           [ invalid; valid1; valid2 ] with
+   | Ok p ->
+     check (p = valid1 || p = valid2)
+       "choose_valid: funnel-invalid sample never elected";
+     check (p <> invalid)
+       "choose_valid: canonical response is a funnel-valid sample"
+   | Error e -> fail ("choose_valid: valid pair errored: " ^ e));
+  (* Negative: zero funnel-valid samples -> explicit Error, no
+     first-argument fallback (the legacy numeric mode would have
+     returned the invalid sample here). *)
+  (match Witness_medoid.choose_valid ~expected_target:"spec" [ invalid ] with
+   | Error _ -> pass "choose_valid: zero valid samples is an explicit Error"
+   | Ok p -> fail ("choose_valid: zero-valid case elected " ^ p));
+  (* Contrast pin: the legacy numeric election DOES admit the invalid
+     sample — the two modes must stay distinguishable. *)
+  (match Witness_medoid.choose [ invalid ] with
+   | Ok p ->
+     check (p = invalid)
+       "choose (legacy numeric): still admits numerically complete samples"
+   | Error e -> fail ("choose legacy contrast errored: " ^ e));
+  (* Empty input refused in valid mode too. *)
+  (match Witness_medoid.choose_valid ~expected_target:"spec" [] with
+   | Error _ -> pass "choose_valid: empty input refused"
+   | Ok _ -> fail "choose_valid: empty input accepted")
+
+(* ------------------------------------------------------------------ *)
 
 let () =
   test_valid_v32_deltas ();
@@ -420,4 +483,5 @@ let () =
   test_funnel_cards_missing_with_defects ();
   test_funnel_cards_duplicate_id ();
   test_funnel_cards_two_primary_axes ();
+  test_medoid_choose_valid_excludes_funnel_invalid ();
   Printf.printf "All response_schema v3.2 strict validation tests passed.\n%!"

--- a/engine/ocaml/test/test_response_schema.ml
+++ b/engine/ocaml/test/test_response_schema.ml
@@ -187,6 +187,7 @@ let witness_raw ?(delta_ab = "0.1") ?(extra = "")
     ?(alpha_checklist = clean_checklist alpha_cats)
     ?(beta_checklist = clean_checklist beta_cats)
     ?(gamma_checklist = clean_checklist gamma_cats)
+    ?(defect_cards = "[]")
     () = Printf.sprintf {|{
   "target": "spec",
   "alpha": 0.9, "beta": 0.8, "gamma": 0.7,
@@ -200,8 +201,9 @@ let witness_raw ?(delta_ab = "0.1") ?(extra = "")
     "gamma": {"positive": ["p"], "negative": ["n"], "reason": "r", "checklist": %s}
   },
   "unresolved_ambiguity": [],
-  "next_fixes": []%s
-}|} delta_ab alpha_checklist beta_checklist gamma_checklist extra
+  "next_fixes": [],
+  "defect_cards": %s%s
+}|} delta_ab alpha_checklist beta_checklist gamma_checklist defect_cards extra
 
 let valid_witness_raw = witness_raw ()
 
@@ -303,8 +305,19 @@ let test_funnel_severity_count_mismatch () =
          "unstable-boundary": {"count": 0, "severity": "none"}}|} ())
     "checklist"
 
+let nonzero_beta_cards = {|[
+  {"id": "D1", "primary_axis": "beta", "category": "broken-reference",
+   "severity": "isolated", "evidence": "f:1", "summary": "ref one"},
+  {"id": "D2", "primary_axis": "beta", "category": "broken-reference",
+   "severity": "cosmetic", "evidence": "f:2", "summary": "ref two"},
+  {"id": "D3", "primary_axis": "beta", "category": "fact-drift",
+   "severity": "cosmetic", "evidence": "f:3", "summary": "drift one",
+   "secondary_axes": ["gamma"]}
+]|}
+
 let test_funnel_accepts_nonzero_walk () =
   let raw = witness_raw
+    ~defect_cards:nonzero_beta_cards
     ~beta_checklist:{|{"broken-reference": {"count": 2, "severity": "isolated"},
       "authority-conflict": {"count": 0, "severity": "none"},
       "fact-drift": {"count": 1, "severity": "cosmetic"},
@@ -317,6 +330,58 @@ let test_funnel_accepts_nonzero_walk () =
   | Error wf ->
     fail ("funnel positive: non-zero walk refused: "
           ^ Response_schema.format_witness_failure wf)
+
+(* v3.2.4 defect-card stage: cards are required when the walk counts
+   defects, and must reconcile with the checklist. *)
+
+let nonzero_beta_checklist =
+  {|{"broken-reference": {"count": 2, "severity": "isolated"},
+    "authority-conflict": {"count": 0, "severity": "none"},
+    "fact-drift": {"count": 1, "severity": "cosmetic"},
+    "undeclared-relationship": {"count": 0, "severity": "none"}}|}
+
+let test_funnel_cards_missing_with_defects () =
+  expect_stage "funnel negative: walk counts defects but no cards"
+    ~expected_target:"spec"
+    (witness_raw ~beta_checklist:nonzero_beta_checklist ())
+    "defect_cards"
+
+let test_funnel_cards_duplicate_id () =
+  let cards = {|[
+    {"id": "D1", "primary_axis": "beta", "category": "broken-reference",
+     "severity": "isolated", "evidence": "f:1", "summary": "ref one"},
+    {"id": "D1", "primary_axis": "beta", "category": "broken-reference",
+     "severity": "cosmetic", "evidence": "f:2", "summary": "ref two"},
+    {"id": "D3", "primary_axis": "beta", "category": "fact-drift",
+     "severity": "cosmetic", "evidence": "f:3", "summary": "drift"}
+  ]|} in
+  expect_stage "funnel negative: duplicate card id"
+    ~expected_target:"spec"
+    (witness_raw ~defect_cards:cards
+       ~beta_checklist:nonzero_beta_checklist ())
+    "defect_cards"
+
+let test_funnel_cards_two_primary_axes () =
+  (* identical evidence+summary filed under two primary axes *)
+  let cards = {|[
+    {"id": "D1", "primary_axis": "beta", "category": "broken-reference",
+     "severity": "isolated", "evidence": "same", "summary": "same defect"},
+    {"id": "D2", "primary_axis": "beta", "category": "broken-reference",
+     "severity": "cosmetic", "evidence": "f:2", "summary": "ref two"},
+    {"id": "D3", "primary_axis": "beta", "category": "fact-drift",
+     "severity": "cosmetic", "evidence": "f:3", "summary": "drift"},
+    {"id": "D4", "primary_axis": "alpha", "category": "internal-contradiction",
+     "severity": "isolated", "evidence": "same", "summary": "same defect"}
+  ]|} in
+  let alpha = {|{"naming-drift": {"count": 0, "severity": "none"},
+    "duplicate-definition": {"count": 0, "severity": "none"},
+    "internal-contradiction": {"count": 1, "severity": "isolated"},
+    "unstable-boundary": {"count": 0, "severity": "none"}}|} in
+  expect_stage "funnel negative: one defect under two primary axes"
+    ~expected_target:"spec"
+    (witness_raw ~defect_cards:cards ~alpha_checklist:alpha
+       ~beta_checklist:nonzero_beta_checklist ())
+    "defect_cards"
 
 let test_funnel_delta_failure_classified () =
   (* Base-valid response with one delta out of range: must be classified as
@@ -352,4 +417,7 @@ let () =
   test_funnel_unknown_category ();
   test_funnel_severity_count_mismatch ();
   test_funnel_accepts_nonzero_walk ();
+  test_funnel_cards_missing_with_defects ();
+  test_funnel_cards_duplicate_id ();
+  test_funnel_cards_two_primary_axes ();
   Printf.printf "All response_schema v3.2 strict validation tests passed.\n%!"

--- a/runtime/SELF-MEASURE.md
+++ b/runtime/SELF-MEASURE.md
@@ -264,7 +264,9 @@ grows with k by construction. Hence v3.2.4, not pooled findings.
 primary-axis precedence rule + structured `defect_cards` (machine-
 validated against the checklist) + the k-fair mean-pairwise statistic
 (reported alongside max-pairwise, same barrier). Baseline (v3.2.3,
-k=5, post-hygiene tree, mean-pairwise form): BASELINE_KFAIR_NUMBERS.
+k=5, post-hygiene tree 7d9c3f0, run 28697625576, mean-pairwise form):
+spec 0.833574, engine 0.899250, repo 0.883737 (min: spec); yield 5/5
+on all three targets.
 Pre-registered pass conditions: full sample yield on every target
 (declared == validated); min Coh_consistency_mean_pairwise ≥ 0.85 AND
 ≥ +0.03 over that baseline; ≥ 80% primary-axis agreement on defect

--- a/runtime/SELF-MEASURE.md
+++ b/runtime/SELF-MEASURE.md
@@ -1,4 +1,4 @@
-# Self-Measure v3.2.3
+# Self-Measure v3.2.4
 
 You are evaluating a TSC target bundle.
 
@@ -131,7 +131,7 @@ Do not punish `repo` only because one layer is unfinished if the bundle already 
 
 ---
 
-## 3. Scoring rules — v3.2.3 protocol
+## 3. Scoring rules — v3.2.4 protocol
 
 **Do not output Coh (coherence) values directly. Output normalized discrepancy δ values in [0,1] per pair.**
 
@@ -188,10 +188,26 @@ load-bearing claim contradicted).
 | β | `broken-reference` (a file/anchor/section referenced that the bundle does not bear out) · `authority-conflict` (two files claim or assign authority inconsistently) · `fact-drift` (one fact repeated with diverging values) · `undeclared-relationship` (a dependency asserted or required but not evidenced) |
 | γ | `unowned-change-path` (no owner or rule for how a surface evolves) · `generated-canonical-confusion` (derived artifacts not distinguished from canonical ones) · `missing-migration-rule` (version/format transitions unspecified) · `stale-transitional-marker` (something marked temporary with no exit path) |
 
-Report the walk in `axis_evidence.<axis>.checklist` (contract in §7) —
-the walk is part of the record, not a private step. Also list the
-individual defects (with severities) in the axis's `negative`
-evidence, as before.
+**File each defect under exactly ONE primary axis** (v3.2.4): when a
+defect plausibly fits more than one axis, the FIRST matching rule
+decides the primary axis; every other plausible axis goes in the
+card's `secondary_axes`, never as a second filing:
+
+1. A same-document logical contradiction (two claims in one file
+   cannot both hold) → `alpha` / `internal-contradiction`.
+2. A cross-file claim/source mismatch — authority, citation, path, or
+   repeated-fact divergence between files → `beta` / the matching
+   β category.
+3. A lifecycle defect — version window, migration rule, stale
+   transitional marker, unowned change path → `gamma` / the matching
+   γ category.
+
+Report every defect as a structured card in `defect_cards` (contract
+in §7); the per-axis `checklist` is the aggregate VIEW of those cards
+and the engine refuses a response where the two disagree (counts per
+category; worst severity per category; `none` exactly when no card).
+Also list the defects in the axis's `negative` evidence, as before —
+that remains the human-readable projection.
 
 **Map continuously, guided by the bands** (v3.2.2): use this table as
 INTERPRETATION, not quantization — report any value in the range that
@@ -238,9 +254,24 @@ found a broken cross-reference instead) and mapped their own findings
 honestly. A checklist disciplines the map; it cannot make independent
 readers encounter the same defects in a multi-thousand-line bundle.
 The checklist and the walk-validating funnel stage are retained as
-contract hardening; the next variance experiment must target discovery
-(pooled-findings adjudication: a second witness phase that re-scores
-against the union of all samples' enumerated defects).
+contract hardening. The k=5 characterization pass then showed the
+variance is not primarily in discovery either: witnesses converge on a
+shared defect core (top clusters found by 60–100% of samples) but FILE
+the same defects under different axes, and the max-pairwise statistic
+grows with k by construction. Hence v3.2.4, not pooled findings.
+
+**Experiment record (v3.2.3 → v3.2.4).** Candidate: the §3.2
+primary-axis precedence rule + structured `defect_cards` (machine-
+validated against the checklist) + the k-fair mean-pairwise statistic
+(reported alongside max-pairwise, same barrier). Baseline (v3.2.3,
+k=5, post-hygiene tree, mean-pairwise form): BASELINE_KFAIR_NUMBERS.
+Pre-registered pass conditions: full sample yield on every target
+(declared == validated); min Coh_consistency_mean_pairwise ≥ 0.85 AND
+≥ +0.03 over that baseline; ≥ 80% primary-axis agreement on defect
+clusters found by ≥ 3/5 witnesses; mechanical cross within 0.005;
+max-pairwise fields still reported; no standing promotion. A miss on
+any condition marks the meter-loop counter 2/2. Result recorded here
+when measured.
 
 **Confidence rubric**: 0.9 — you read every file and your findings are
 all directly cited; 0.75 — some claims reference material outside the
@@ -358,6 +389,17 @@ Return JSON only.
       }
     }
   },
+  "defect_cards": [
+    {
+      "id": "D1",
+      "primary_axis": "alpha",
+      "category": "internal-contradiction",
+      "severity": "systemic",
+      "evidence": "path or §-citation the defect is visible at",
+      "summary": "one-sentence statement of the defect",
+      "secondary_axes": ["beta"]
+    }
+  ],
   "unresolved_ambiguity": ["..."],
   "next_fixes": [
     {
@@ -372,6 +414,16 @@ No markdown.
 No prose before or after the JSON.
 
 **Key difference from v3.1:** The three `delta_*` fields are **required**. They carry normalized discrepancy δ ∈ [0, 1] for each pair. The engine applies the barrier transform to obtain Coh values — do not compute Coh yourself.
+
+**Key difference from v3.2.3:** `defect_cards` is **required** whenever
+the walk counts any defect (it MAY be an empty array only when every
+category counts 0). Each card carries `id` (unique), `primary_axis`
+(exactly one, by the §3.2 precedence), `category` (a checklist category
+OF that axis), `severity` (`cosmetic|isolated|systemic` — never `none`:
+a card IS a defect), `evidence`, `summary`, and optional
+`secondary_axes`. The engine refuses duplicate ids, a defect filed
+under two primary axes, categories foreign to the primary axis, and
+any card/checklist disagreement.
 
 **Key difference from v3.2.2:** each axis's `checklist` is **required**,
 with exactly the categories in §3.2 — every category present, `count`

--- a/runtime/SELF-MEASURE.md
+++ b/runtime/SELF-MEASURE.md
@@ -272,8 +272,30 @@ Pre-registered pass conditions: full sample yield on every target
 ≥ +0.03 over that baseline; ≥ 80% primary-axis agreement on defect
 clusters found by ≥ 3/5 witnesses; mechanical cross within 0.005;
 max-pairwise fields still reported; no standing promotion. A miss on
-any condition marks the meter-loop counter 2/2. Result recorded here
-when measured.
+any condition marks the meter-loop counter 2/2.
+
+**Result (measured, k=5 run 28703325203 on tree b377ac2): FAILED —
+meter-loop counter 2/2.** Mean-pairwise: spec 0.800520 (−0.033),
+engine 0.912376 (+0.013), repo 0.724998 (−0.159, k=4/5). Conditions
+missed: yield (repo 4/5 — and the incidental PR-event run on the same
+tree drew spec 3/5, two samples omitting the checklist walk
+entirely); min ≥ 0.85 (0.725); +0.03 margin (two targets moved
+NEGATIVE). Axis agreement on ≥3/5 clusters was mixed (spec:
+ε-miscitation 4/4 β, "witness" overload 3/3 α, but oper §7.3-vs-§8
+split α/γ/γ — one witness applied the precedence rule, two filed the
+same defect as a stale marker). Mechanical A/B bit-identical;
+max-pairwise reported; no standing promotion — those three held.
+Interpretation: structured cards did not reduce filing variance, and
+the longer contract REDUCED sample yield; one repo witness returned
+checklist counts an order of magnitude beyond its peers, which
+mean-pairwise dampens but cannot absorb. The defect-card funnel stage
+and dual-statistic reporting are retained as contract hardening (no
+consistency claim); llm_repeats reverts to 3. Two pipeline defects
+this run exposed: witness-medoid elects among numerically-complete
+samples without funnel validity (an invalid sample can be
+adjudicated, failing ingest), and three v3.2.4 error strings in
+response_schema.ml carry baked multi-space runs. The loop counter is
+exhausted; next protocol change requires operator dispatch.
 
 **Confidence rubric**: 0.9 — you read every file and your findings are
 all directly cited; 0.75 — some claims reference material outside the

--- a/scripts/ci/self-measure-smoke.sh
+++ b/scripts/ci/self-measure-smoke.sh
@@ -81,7 +81,7 @@ for fixture in skills/self-measure/fixtures/invalid/*.json; do
   fi
   artifact=$(ls "$OUT_INVALID"/tsc-spec-*-validation-failure.json 2>/dev/null | head -1)
   [[ -n "$artifact" ]] || fail "no validation-failure artifact: $case_name"
-  stage=$(python3 -c "import json,sys; print(json.load(open(sys.argv[1]))['stage'])" "$artifact")
+  stage=$(jq -r '.stage' "$artifact")
   [[ "$stage" == "$expect_stage" ]] \
     || fail "$case_name: stage '$stage' != expected '$expect_stage'"
   if ls "$OUT_INVALID"/tsc-spec-*.json 2>/dev/null | grep -v raw | grep -qv validation-failure; then
@@ -107,6 +107,28 @@ picked="$("$COH_BIN" witness-medoid "$MEDOID_DIR"/r1.json "$MEDOID_DIR"/r2.json 
 rm -rf "$MEDOID_DIR"
 echo "ok: witness-medoid election (engine CLI)"
 
+# 5b. Funnel-valid medoid election (post-loop Issue 1): with --target,
+#     a NUMERICALLY complete but funnel-invalid sample must never be
+#     adjudicated, and zero funnel-valid samples must exit 2 (the
+#     workflow then records the no-valid-samples artifact instead of
+#     hard-failing ingest on a sample the funnel already refused).
+VALID_DIR="$(mktemp -d)"
+cp skills/self-measure/fixtures/witness-response-valid.json "$VALID_DIR/v1.json"
+cp skills/self-measure/fixtures/witness-response-valid.json "$VALID_DIR/v2.json"
+cp skills/self-measure/fixtures/invalid/cards-duplicate-id.json "$VALID_DIR/bad.json"
+# Positive: invalid sample listed FIRST still loses; a valid sample is
+# elected (tie between identical valids breaks earliest).
+picked="$("$COH_BIN" witness-medoid --target spec \
+  "$VALID_DIR"/bad.json "$VALID_DIR"/v1.json "$VALID_DIR"/v2.json)"
+[[ "$picked" == "$VALID_DIR/v1.json" || "$picked" == "$VALID_DIR/v2.json" ]] \
+  || fail "witness-medoid --target: funnel-invalid sample elected: $picked"
+# Negative: zero funnel-valid samples -> exit 2, nothing on stdout.
+if picked="$("$COH_BIN" witness-medoid --target spec "$VALID_DIR"/bad.json 2>/dev/null)"; then
+  fail "witness-medoid --target: zero-valid case succeeded with: $picked"
+fi
+rm -rf "$VALID_DIR"
+echo "ok: witness-medoid funnel-valid election (invalid never adjudicated, zero-valid exits 2)"
+
 # 6. Source-of-truth guard (Issue A / F1): the consistency module must
 #    route the barrier through Coherence.phi, never define it locally.
 #    The k=5 pass caught exactly this regression once; grep keeps it dead.
@@ -114,5 +136,16 @@ if grep -nE '1\.0 -\. delta|1\. -\. delta' engine/ocaml/lib/consistency.ml; then
   fail "consistency.ml re-implements the barrier locally (must route through Coherence.phi)"
 fi
 echo "ok: consistency barrier routed through Coherence (no local duplicate)"
+
+# 7. Error-string hygiene guard (post-loop Issue 2): refusal messages
+#    are an operator-visible surface; a multi-space run baked inside a
+#    single-line string literal is an editing artifact (an engine
+#    witness found three in the v3.2.4 card errors). Multi-line string
+#    continuations (backslash-newline) are fine — OCaml eats the
+#    continuation whitespace — so only single-line literals are checked.
+if grep -nE '"[^"]*[^ "]  +[^ "][^"]*"' engine/ocaml/lib/response_schema.ml; then
+  fail "response_schema.ml: multi-space run inside a string literal (editing artifact)"
+fi
+echo "ok: response_schema error strings carry no baked multi-space runs"
 
 echo "self-measure-smoke: pass"

--- a/scripts/render-self-measure.sh
+++ b/scripts/render-self-measure.sh
@@ -265,7 +265,7 @@ measure_k = int(req(sm, "consistency.llm_repeats"))
 ledger_k  = int(req(sm, "ledger.semantic_samples"))
 
 
-def consistency_standing_run(t_expr):
+def consistency_standing_run(t_expr, declared_k):
     """Run-block body for the per-target consistency + standing step,
     shared by the measurement workflow (matrix target) and the ledger
     workflow (literal target). Every extra sample is validated through
@@ -286,21 +286,45 @@ def consistency_standing_run(t_expr):
 {ind}  fi
 {ind}done
 {ind}n=$(echo $valid | wc -w)
+{ind}declared={declared_k}
+{ind}refused=$((declared - n))
+{ind}# Refusal-stage counts from the validation-failure artifacts the
+{ind}# funnel wrote for the samples that did not validate.
+{ind}stage_counts=$(cat "{output_root}"/validate/tsc-$T-*-validation-failure.json 2>/dev/null \\
+{ind}  | jq -cs 'map(.stage) | group_by(.) | map({{(.[0]): length}}) | add // {{}}' 2>/dev/null || echo '{{}}')
 {ind}# Defect-overlap observability: per validated sample, the checklist
 {ind}# counts and negative findings, one JSON line each — job logs carry
 {ind}# enough to cluster findings across samples without artifact access.
 {ind}for r in $valid; do
 {ind}  jq -c '{{sample: input_filename, checklist: (.axis_evidence | map_values(.checklist)), negative: (.axis_evidence | map_values(.negative))}}' "$r" || true
 {ind}done
-{ind}coh_c="0"
+{ind}coh_c="0"; coh_kfair="0"
 {ind}if [ "$n" -ge 2 ]; then
 {ind}  COH_BIN="$COH" scripts/cm-consistency.sh llm-spread "$T" $valid || true
-{ind}  coh_c=$(python3 -c "import json,sys; print(json.load(open(sys.argv[1]))['coh_consistency'])" ".tsc/cm/consistency/$T.llm.json" 2>/dev/null || echo 0)
+{ind}  coh_c=$(jq -r '.coh_consistency_max_pairwise' ".tsc/cm/consistency/$T.llm.json" 2>/dev/null || echo 0)
+{ind}  coh_kfair=$(jq -r '.coh_consistency_mean_pairwise' ".tsc/cm/consistency/$T.llm.json" 2>/dev/null || echo 0)
 {ind}  cp ".tsc/cm/consistency/$T.llm.json" "{output_root}/consistency-$T.json" 2>/dev/null || true
 {ind}fi
-{ind}gate=$(python3 -c "import sys; print('passed' if float(sys.argv[1]) >= {llm_consistency_floor} else 'failed')" "$coh_c")
-{ind}python3 -c "import json,sys; json.dump({{'standing_scope': 'house-authored-public-commons', 'admissibility': 'public-only', 'heldout_status': 'none', 'external_anchor_count': 0, 'llm_consistency_gate': sys.argv[4], 'llm_consistency_floor': {llm_consistency_floor}, 'coh_consistency': float(sys.argv[3]), 'validated_samples': int(sys.argv[2]), 'target': sys.argv[1]}}, open('{output_root}/standing-' + sys.argv[1] + '.json', 'w'), indent=2)" "$T" "$n" "$coh_c" "$gate"
-{ind}echo \"consistency: $T k=$n Coh_consistency=$coh_c gate=$gate (standing gate, never a publishing gate)\""""
+{ind}# Standing gate: legacy max-pairwise vs the floor (conservative,
+{ind}# unchanged). kfair_experiment_gate: the yield PRECONDITION only —
+{ind}# a short sample set fails the k-fair experiment regardless of
+{ind}# score; the numeric comparison vs baseline happens at close-out.
+{ind}gate=$(awk -v c="$coh_c" 'BEGIN {{ if (c >= {llm_consistency_floor}) print "passed"; else print "failed" }}')
+{ind}yield_gate=$([ "$n" -eq "$declared" ] && echo passed || echo failed)
+{ind}jq -n --arg target "$T" --argjson declared "$declared" --argjson n "$n" \\
+{ind}      --argjson refused "$refused" --argjson stages "$stage_counts" \\
+{ind}      --argjson coh "$coh_c" --argjson kfair "$coh_kfair" \\
+{ind}      --arg gate "$gate" --arg ygate "$yield_gate" \\
+{ind}      '{{standing_scope: "house-authored-public-commons", admissibility: "public-only",
+{ind}        heldout_status: "none", external_anchor_count: 0,
+{ind}        llm_consistency_gate: $gate, llm_consistency_floor: {llm_consistency_floor},
+{ind}        coh_consistency: $coh,
+{ind}        coh_consistency_max_pairwise: $coh, coh_consistency_mean_pairwise: $kfair,
+{ind}        declared_samples: $declared, validated_samples: $n,
+{ind}        refused_samples: $refused, refusal_stage_counts: $stages,
+{ind}        kfair_experiment_gate: $ygate, target: $target}}' \\
+{ind}      > "{output_root}/standing-$T.json"
+{ind}echo \"consistency: $T k=$n/$declared Coh_max=$coh_c Coh_kfair=$coh_kfair gate=$gate yield=$yield_gate (standing gate, never a publishing gate)\""""
 
 def cli_witness_run(prompt_text, k=1, resp=None):
     """Run-block body for a CLI witness step. Every emitted line sits at
@@ -373,7 +397,7 @@ def cli_witness_run(prompt_text, k=1, resp=None):
 {ind}# repo witness mid-read (run 3).
 {claude_call}"""
 
-matrix_consistency = consistency_standing_run("${{ matrix.target }}")
+matrix_consistency = consistency_standing_run("${{ matrix.target }}", measure_k)
 
 build_steps = """      - uses: actions/checkout@v4
 
@@ -616,7 +640,7 @@ def ledger_witness_steps():
         if: ${{{{ env.{llm_secret} != '' }}}}
         continue-on-error: true
         run: |
-{consistency_standing_run(t)}""")
+{consistency_standing_run(t, ledger_k)}""")
     return "\n\n".join(blocks)
 
 ledger_witness = ledger_witness_steps()

--- a/scripts/render-self-measure.sh
+++ b/scripts/render-self-measure.sh
@@ -311,6 +311,18 @@ def consistency_standing_run(t_expr, declared_k):
 {ind}# score; the numeric comparison vs baseline happens at close-out.
 {ind}gate=$(awk -v c="$coh_c" 'BEGIN {{ if (c >= {llm_consistency_floor}) print "passed"; else print "failed" }}')
 {ind}yield_gate=$([ "$n" -eq "$declared" ] && echo passed || echo failed)
+{ind}# Zero funnel-valid samples: explicit artifact (post-loop Issue 1).
+{ind}# No hybrid report exists, standing below records validated 0 —
+{ind}# expected witness invalidity stays green; only a pipeline failure
+{ind}# (this artifact unwritable) may redden the job.
+{ind}if [ "$n" -eq 0 ]; then
+{ind}  jq -n --arg target "$T" --argjson declared "$declared" \\
+{ind}        --argjson refused "$refused" --argjson stages "$stage_counts" \\
+{ind}        '{{target: $target, status: "no_valid_witness_samples",
+{ind}          declared_samples: $declared, validated_samples: 0,
+{ind}          refused_samples: $refused, refusal_stage_counts: $stages}}' \\
+{ind}        > "{output_root}/no-valid-witness-samples-$T.json"
+{ind}fi
 {ind}jq -n --arg target "$T" --argjson declared "$declared" --argjson n "$n" \\
 {ind}      --argjson refused "$refused" --argjson stages "$stage_counts" \\
 {ind}      --argjson coh "$coh_c" --argjson kfair "$coh_kfair" \\
@@ -334,16 +346,20 @@ def cli_witness_run(prompt_text, k=1, resp=None):
     (consistency protocol, cm-of-cms skill section 3): each sample is
     moved aside as .rN.json and the MEDOID sample (minimum total L1
     distance to the others over the numeric contract fields —
-    `coh witness-medoid`, lib/witness_medoid.ml) is restored as the
-    response the ingest step adjudicates. All samples still feed the consistency spread;
-    the medoid changes which real response is adjudicated, never the
-    spread (v3.2.3: first-sample order luck removed)."""
+    `coh witness-medoid --target`, lib/witness_medoid.ml) is restored
+    as the response the ingest step adjudicates. Only FUNNEL-VALID
+    samples are electable (post-loop Issue 1); zero valid samples
+    withholds adjudication so the ingest step skips green. All valid
+    samples still feed the consistency spread; the medoid changes which
+    real response is adjudicated, never the spread (v3.2.3:
+    first-sample order luck removed)."""
     ind = "          "
     prompt_block = "\n".join(
         (ind + line).rstrip() for line in prompt_text.rstrip("\n").split("\n")
     )
     if k > 1:
         claude_call = f"""{ind}RESP="{resp}"; BASE="${{RESP%.json}}"
+{ind}T="$(basename "$RESP" .json)"
 {ind}for i in $(seq 1 {k}); do
 {ind}  claude -p "$(cat "$RUNNER_TEMP/witness-prompt.md")" \\
 {ind}    --settings "$RUNNER_TEMP/witness-settings.json" \\
@@ -351,12 +367,20 @@ def cli_witness_run(prompt_text, k=1, resp=None):
 {ind}    --max-turns 50 || true
 {ind}  if [ -f "$RESP" ]; then mv "$RESP" "$BASE.r$i.json"; fi
 {ind}done
-{ind}# Medoid-of-k adjudication (v3.2.3): the adjudicated response is
-{ind}# the sample nearest the others over the numeric contract fields —
-{ind}# a real witness response, not first-sample order luck. All samples
-{ind}# still feed the consistency spread.
+{ind}# Medoid-of-k adjudication (v3.2.3; funnel-valid election, post-loop
+{ind}# Issue 1): --target makes only samples that pass the COMPLETE
+{ind}# witness funnel electable — the same set the consistency spread is
+{ind}# computed over — so an invalid sample can never be adjudicated into
+{ind}# a guaranteed ingest failure. Zero funnel-valid samples leaves the
+{ind}# canonical response absent: the ingest step skips, and the
+{ind}# consistency step records the explicit no-valid-samples artifact
+{ind}# (expected witness invalidity is DATA, not a pipeline failure).
 {ind}if ls "$BASE".r*.json >/dev/null 2>&1; then
-{ind}  cp "$("$PWD/engine/ocaml/_build/default/bin/main.exe" witness-medoid "$BASE".r*.json)" "$RESP"
+{ind}  if elected="$("$PWD/engine/ocaml/_build/default/bin/main.exe" witness-medoid --target "$T" "$BASE".r*.json)"; then
+{ind}    cp "$elected" "$RESP"
+{ind}  else
+{ind}    echo "witness-medoid: no funnel-valid sample for $T — adjudication withheld"
+{ind}  fi
 {ind}fi
 {ind}ls -l "$(dirname "$RESP")" || true"""
     else:
@@ -544,8 +568,16 @@ jobs:
           LLM_PROVIDER: claude-cli
           LLM_MODEL: claude-code-cli@{CLAUDE_CLI_VERSION}
         run: |
-          COH_BIN="$PWD/engine/ocaml/_build/default/bin/main.exe" \\
-            {command_out} --ingest ${{{{ matrix.target }}}} --output {output_root}
+          # Absent response = zero funnel-valid samples (adjudication
+          # withheld upstream). That is witness data, not a pipeline
+          # failure: skip green; the consistency step records the
+          # no-valid-samples artifact and failed standing.
+          if [ -f "{output_root}/response/${{{{ matrix.target }}}}.json" ]; then
+            COH_BIN="$PWD/engine/ocaml/_build/default/bin/main.exe" \\
+              {command_out} --ingest ${{{{ matrix.target }}}} --output {output_root}
+          else
+            echo "no funnel-valid witness samples — ingest skipped"
+          fi
 
       # Consistency protocol, LLM arm (cm-of-cms skill section 3): every
       # extra sample is validated through the same witness funnel; the
@@ -633,8 +665,15 @@ def ledger_witness_steps():
           LLM_PROVIDER: claude-cli
           LLM_MODEL: claude-code-cli@{CLAUDE_CLI_VERSION}
         run: |
-          COH_BIN="$PWD/engine/ocaml/_build/default/bin/main.exe" \\
-            {command_out} --ingest {t} --output {output_root}
+          # Same skip-green rule as the measurement route: an absent
+          # response means zero funnel-valid samples, recorded by the
+          # consistency step — not a pipeline failure.
+          if [ -f "{output_root}/response/{t}.json" ]; then
+            COH_BIN="$PWD/engine/ocaml/_build/default/bin/main.exe" \\
+              {command_out} --ingest {t} --output {output_root}
+          else
+            echo "no funnel-valid witness samples — ingest skipped"
+          fi
 
       - name: Witness consistency ({t}, k={ledger_k} spread) and standing scope
         if: ${{{{ env.{llm_secret} != '' }}}}

--- a/skills/cm-of-cms/SKILL.md
+++ b/skills/cm-of-cms/SKILL.md
@@ -91,6 +91,7 @@ cm_of_cms:
       - confidence
       - summary
       - axis_evidence
+      - defect_cards
       - unresolved_ambiguity
       - next_fixes
     must_not:
@@ -110,7 +111,9 @@ cm_of_cms:
       engine/ocaml/lib/response_schema.ml (validate_witness_response) —
       one funnel for every refusal stage: parse, base_schema,
       prohibited_fields (computed Coh/C_sigma), target_mismatch,
-      v3_2_delta, checklist (v3.2.3 defect walk missing or malformed).
+      v3_2_delta, checklist (v3.2.3 defect walk missing or malformed),
+      defect_cards (v3.2.4 structured cards missing, malformed, or
+      disagreeing with the checklist).
       Any refusal produces a durable validation-failure
       artifact naming its stage, preserves the raw response, renders no
       coherence report, and never falls back to mechanical scoring

--- a/skills/self-measure/SKILL.md
+++ b/skills/self-measure/SKILL.md
@@ -56,11 +56,15 @@ self_measure:
       stage counts; a short yield fails the k-fair experiment
       regardless of score
     adjudication: >-
-      medoid-of-k (v3.2.3): the adjudicated response is the validated
-      sample with minimum total L1 distance to the other samples over
-      the same numeric fields the spread is computed on
-      (coh witness-medoid, engine/ocaml/lib/witness_medoid.ml) — a real witness response, never
-      first-sample order luck; adjudication never changes the spread
+      medoid-of-k (v3.2.3): the adjudicated response is the FUNNEL-VALID
+      sample with minimum total L1 distance to the other valid samples
+      over the same numeric fields the spread is computed on
+      (coh witness-medoid --target, engine/ocaml/lib/witness_medoid.ml)
+      — a real witness response, never first-sample order luck, never a
+      sample the funnel refuses; zero valid samples withholds
+      adjudication and records a no_valid_witness_samples artifact
+      instead of failing the pipeline; adjudication never changes the
+      spread
     script: scripts/cm-consistency.sh
   mechanical:
     backend: engine/ocaml/lib/mechanical_scoring.ml

--- a/skills/self-measure/SKILL.md
+++ b/skills/self-measure/SKILL.md
@@ -42,12 +42,19 @@ self_measure:
   default_mode: auto
   consistency:
     mechanical: identical
-    llm_repeats: 3
+    llm_repeats: 5
     llm_spread: >-
       max absolute pairwise difference over the response contract's
       numeric fields; delta_consistency maps through the barrier
       phi(delta) = delta/(1-delta) to Coh_consistency = exp(-phi)
-      (tsc-core section 3.2, lambda = 1)
+      (tsc-core section 3.2, lambda = 1). Reported alongside (A/B
+      labeled, Issue D): the k-fair companion — MEAN absolute pairwise
+      difference per field, max across fields, same barrier — under
+      *_mean_pairwise names; max-pairwise stays the conservative
+      standing metric unless separately promoted. A report also
+      carries declared/validated/refused sample counts and refusal
+      stage counts; a short yield fails the k-fair experiment
+      regardless of score
     adjudication: >-
       medoid-of-k (v3.2.3): the adjudicated response is the validated
       sample with minimum total L1 distance to the other samples over

--- a/skills/self-measure/SKILL.md
+++ b/skills/self-measure/SKILL.md
@@ -96,6 +96,7 @@ self_measure:
       - confidence
       - summary
       - axis_evidence
+      - defect_cards
       - unresolved_ambiguity
       - next_fixes
     must_not:
@@ -115,7 +116,9 @@ self_measure:
       engine/ocaml/lib/response_schema.ml (validate_witness_response) —
       one funnel for every refusal stage: parse, base_schema,
       prohibited_fields (computed Coh/C_sigma), target_mismatch,
-      v3_2_delta, checklist (v3.2.3 defect walk missing or malformed).
+      v3_2_delta, checklist (v3.2.3 defect walk missing or malformed),
+      defect_cards (v3.2.4 structured cards missing, malformed, or
+      disagreeing with the checklist).
       Any refusal produces a durable validation-failure
       artifact naming its stage, preserves the raw response, renders no
       coherence report, and never falls back to mechanical scoring
@@ -344,7 +347,9 @@ malformed text), `base_schema` (missing/mistyped contract fields),
 `prohibited_fields` (computed coherence), `target_mismatch` (response
 names a different target than was measured), `v3_2_delta` (missing or
 out-of-range δ), `checklist` (v3.2.3 defect walk missing, wrong
-category set, or severity/count inconsistent) — and **every** stage
+category set, or severity/count inconsistent), `defect_cards` (v3.2.4
+structured cards missing, malformed, or disagreeing with the
+checklist) — and **every** stage
 writes the same durable
 validation-failure artifact naming its stage, preserves the raw response,
 renders **no** report, and does **not** fall back to mechanical scoring.

--- a/skills/self-measure/SKILL.md
+++ b/skills/self-measure/SKILL.md
@@ -42,7 +42,7 @@ self_measure:
   default_mode: auto
   consistency:
     mechanical: identical
-    llm_repeats: 5
+    llm_repeats: 3
     llm_spread: >-
       max absolute pairwise difference over the response contract's
       numeric fields; delta_consistency maps through the barrier

--- a/skills/self-measure/fixtures/invalid/cards-category-foreign-axis.expect
+++ b/skills/self-measure/fixtures/invalid/cards-category-foreign-axis.expect
@@ -1,0 +1,1 @@
+defect_cards

--- a/skills/self-measure/fixtures/invalid/cards-category-foreign-axis.json
+++ b/skills/self-measure/fixtures/invalid/cards-category-foreign-axis.json
@@ -103,7 +103,7 @@
     {
       "id": "D1",
       "primary_axis": "alpha",
-      "category": "naming-drift",
+      "category": "broken-reference",
       "severity": "cosmetic",
       "evidence": "fixture:1",
       "summary": "minor naming drift (fixture)",

--- a/skills/self-measure/fixtures/invalid/cards-count-mismatch.expect
+++ b/skills/self-measure/fixtures/invalid/cards-count-mismatch.expect
@@ -1,0 +1,1 @@
+defect_cards

--- a/skills/self-measure/fixtures/invalid/cards-count-mismatch.json
+++ b/skills/self-measure/fixtures/invalid/cards-count-mismatch.json
@@ -119,15 +119,6 @@
       "secondary_axes": [
         "alpha"
       ]
-    },
-    {
-      "id": "D3",
-      "primary_axis": "gamma",
-      "category": "missing-migration-rule",
-      "severity": "isolated",
-      "evidence": "fixture:3",
-      "summary": "migration thin (fixture)",
-      "secondary_axes": []
     }
   ]
 }

--- a/skills/self-measure/fixtures/invalid/cards-duplicate-id.expect
+++ b/skills/self-measure/fixtures/invalid/cards-duplicate-id.expect
@@ -1,0 +1,1 @@
+defect_cards

--- a/skills/self-measure/fixtures/invalid/cards-duplicate-id.json
+++ b/skills/self-measure/fixtures/invalid/cards-duplicate-id.json
@@ -110,7 +110,7 @@
       "secondary_axes": []
     },
     {
-      "id": "D2",
+      "id": "D1",
       "primary_axis": "beta",
       "category": "authority-conflict",
       "severity": "isolated",

--- a/skills/self-measure/fixtures/invalid/cards-missing-with-defects.expect
+++ b/skills/self-measure/fixtures/invalid/cards-missing-with-defects.expect
@@ -1,0 +1,1 @@
+defect_cards

--- a/skills/self-measure/fixtures/invalid/cards-missing-with-defects.json
+++ b/skills/self-measure/fixtures/invalid/cards-missing-with-defects.json
@@ -98,36 +98,5 @@
       "axis": "gamma",
       "fix": "test fixture"
     }
-  ],
-  "defect_cards": [
-    {
-      "id": "D1",
-      "primary_axis": "alpha",
-      "category": "naming-drift",
-      "severity": "cosmetic",
-      "evidence": "fixture:1",
-      "summary": "minor naming drift (fixture)",
-      "secondary_axes": []
-    },
-    {
-      "id": "D2",
-      "primary_axis": "beta",
-      "category": "authority-conflict",
-      "severity": "isolated",
-      "evidence": "fixture:2",
-      "summary": "authority gap (fixture)",
-      "secondary_axes": [
-        "alpha"
-      ]
-    },
-    {
-      "id": "D3",
-      "primary_axis": "gamma",
-      "category": "missing-migration-rule",
-      "severity": "isolated",
-      "evidence": "fixture:3",
-      "summary": "migration thin (fixture)",
-      "secondary_axes": []
-    }
   ]
 }

--- a/skills/self-measure/fixtures/invalid/cards-severity-mismatch.expect
+++ b/skills/self-measure/fixtures/invalid/cards-severity-mismatch.expect
@@ -1,0 +1,1 @@
+defect_cards

--- a/skills/self-measure/fixtures/invalid/cards-severity-mismatch.json
+++ b/skills/self-measure/fixtures/invalid/cards-severity-mismatch.json
@@ -113,7 +113,7 @@
       "id": "D2",
       "primary_axis": "beta",
       "category": "authority-conflict",
-      "severity": "isolated",
+      "severity": "cosmetic",
       "evidence": "fixture:2",
       "summary": "authority gap (fixture)",
       "secondary_axes": [

--- a/skills/self-measure/fixtures/invalid/cards-two-primary-axes.expect
+++ b/skills/self-measure/fixtures/invalid/cards-two-primary-axes.expect
@@ -1,0 +1,1 @@
+defect_cards

--- a/skills/self-measure/fixtures/invalid/cards-two-primary-axes.json
+++ b/skills/self-measure/fixtures/invalid/cards-two-primary-axes.json
@@ -55,8 +55,8 @@
           "severity": "isolated"
         },
         "fact-drift": {
-          "count": 0,
-          "severity": "none"
+          "count": 1,
+          "severity": "cosmetic"
         },
         "undeclared-relationship": {
           "count": 0,
@@ -127,6 +127,15 @@
       "severity": "isolated",
       "evidence": "fixture:3",
       "summary": "migration thin (fixture)",
+      "secondary_axes": []
+    },
+    {
+      "id": "D9",
+      "primary_axis": "beta",
+      "category": "fact-drift",
+      "severity": "cosmetic",
+      "evidence": "fixture:1",
+      "summary": "minor naming drift (fixture)",
       "secondary_axes": []
     }
   ]


### PR DESCRIPTION
## Description

Fourth and final item of the CDD wave `meter-v3.2.4-prep` (after #66 hygiene, #67 spec correctness, #68 credentials). Builds SELF-MEASURE v3.2.4 as structured defect-card assignment plus k-fair reporting — not pooled findings, not a standing promotion, not a prose-only rubric.

This PR may claim **contract hardening** (a machine-validated defect surface with six new refusal paths) and **statistic fairness** (a k-monotone-free consistency form reported alongside the conservative legacy form). It must **not** claim witness consistency improvement: that claim is pre-registered and pending the k=5 experiment run this branch triggers. The gate verdict will be recorded here and in the instruction's experiment record when the run lands.

Fixes #(no tracked issue — wave dispatched by operator review)

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update
- [x] Test coverage improvement

## Changes Made

- **v3.2.4 instruction** (`runtime/SELF-MEASURE.md`): primary-axis precedence rule (same-document contradiction → alpha; cross-file claim/source mismatch → beta; lifecycle/version/migration → gamma; first match wins, others secondary) + structured `defect_cards` contract; experiment record pre-registers the seven pass conditions and the v3.2.3 k=5 baseline (spec 0.833574, engine 0.899250, repo 0.883737, mean-pairwise, tree 7d9c3f0, run 28697625576).
- **Typed defect surface** (`types.ml`): `defect_card` record; `measure_result` gains `result_defect_cards`; protocol constant bumped to `SELF-MEASURE/3.2.4` (test-pinned to the instruction's title and §3 header).
- **Funnel stage `defect_cards`** (`response_schema.ml`): cards required iff checklist counts > 0; refusals for duplicate id, same evidence+summary under two primary axes, category foreign to the primary axis, per-(axis,category) count/severity mismatch vs the checklist walk, secondary-axes hygiene.
- **k-fair statistic** (`witness_numeric.ml`, `consistency.ml`): per-field mean of all pairwise |diffs|, max across fields, same barrier — emitted as `*_mean_pairwise` beside the unchanged legacy `*_max_pairwise` standing metric, with `statistic` labels.
- **Sample-yield semantics** (renderer + standing JSON): `declared_samples` / `validated_samples` / `refused_samples` / `refusal_stage_counts` + `kfair_experiment_gate` (yield precondition: declared == validated).
- **Skill declarations**: `llm_repeats: 5` for the experiment (revert to 3 unless promoted); both skills' validation prose and estimates name all seven funnel stages including `defect_cards`.
- **Fixtures**: valid response now carries a checklist-matched card set; six new `invalid/cards-*` fixtures exercise every refusal path in the smoke test.

## Testing

**Test commands run:**

```bash
dune build
dune runtest
scripts/ci/self-measure-smoke.sh <fresh binary>   # incl. 6 defect_cards refusals + barrier-duplication guard + medoid election
scripts/ci/validate-skill-frontmatter.sh          # both skills ok
scripts/render-self-measure.sh --check            # all three rendered artifacts clean
```

**New tests added:**

- [x] Yes

k-fair unit anchors (mean 0.166667 for diffs 0.04/0.25/0.21; an agreeing 4th sample lowers the mean while max stays 0.25), protocol-version pin test, defect-card funnel negatives, table-driven credential-shape tests retained green.

**Manual testing performed:**

Baseline numbers read from run 28697625576 job logs (all 5 jobs green, full 5/5 yield on all targets).

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`dune runtest`)
- [x] Any dependent changes have been merged and published (#66, #67, #68)
- [ ] I have updated CHANGELOG.md (deliberately deferred: no release from the loop; the ledger row/CHANGELOG entry belongs to the next release cut)

## Breaking Changes

None for report consumers: report `schema_version` stays `v3.2.0`; `defect_cards` is additive. Witness responses without cards are refused only when their checklist declares defects — the pre-v3.2.4 zero-defect shape still validates.

## Additional Context

Pre-registered gate (all seven must hold; a miss marks the meter-loop counter 2/2): (1) declared == validated on all targets; (2) min Coh_consistency_mean_pairwise ≥ 0.85; (3) ≥ +0.03 over the v3.2.3 baseline above; (4) ≥ 80% primary-axis agreement on defect clusters found by ≥ 3/5 witnesses; (5) mechanical cross within 0.005; (6) max-pairwise fields still reported; (7) no standing_scope promotion.

## Reviewer Notes

The experiment run triggered by this push is the v3.2.4 measurement; hold merge until the gate verdict is recorded here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ks8wtULXPtFaehDbnEGgdr

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ks8wtULXPtFaehDbnEGgdr)_