### PR TITLE
Post-loop stabilization wave: meter-found content hygiene + decision record + defect-harvesting design

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,41 @@ Discrepancy → coherence link refactored as a typed transformation chain `δ �
 
 ---
 
+## Witness-protocol releases (SELF-MEASURE)
+
+The witness scoring instruction (`runtime/SELF-MEASURE.md`) versions
+independently from both the spec lineage and the engine; its detailed
+experiment records (predictions, baselines, measured results,
+falsifications) live inside the instruction itself. This index exists
+so protocol migrations are recorded at the repository's designated
+process-history location.
+
+### SELF-MEASURE v3.2.4 (2026-07-04) — Defect cards + k-fair statistic (experiment FAILED)
+
+Structured `defect_cards` with a primary-axis precedence rule,
+machine-validated against the v3.2.3 checklist (new `defect_cards`
+funnel stage), plus the k-fair mean-pairwise consistency statistic
+reported beside the unchanged max-pairwise standing metric, and
+sample-yield observability. The pre-registered consistency-improvement
+gate FAILED (missed yield, min ≥ 0.85, and the +0.03 margin; two
+targets moved negative) — meter-loop counter 2/2, loop stopped. The
+card surface and dual-statistic reporting are retained as contract
+hardening with no consistency claim. A temporary k=5 sampling window
+(experiment scope only) opened with the v3.2.3 baseline run and closed
+with the verdict; the measurement route is k=3 again, as the 0.11.0
+ledger row states.
+
+### SELF-MEASURE v3.2.3 (2026-07-04) — Per-axis defect checklist + medoid-of-k (consistency claim falsified)
+
+Per-axis 4-category defect checklist with severities (new `checklist`
+funnel stage) and medoid-of-k adjudication replacing first-sample
+selection. The pre-registered claim (per-target k=3 Coh_consistency
++0.10) was FALSIFIED (+0.0128, noise-level) — meter-loop counter 1/2.
+Checklist and funnel stage retained as contract hardening; the
+falsification is recorded in the instruction's experiment record.
+
+---
+
 ## Engine releases
 
 ## Release Coherence Ledger

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ CC-BY-4.0
   title   = {TSC: Triadic Self-Coherence Framework},
   author  = {Peter Lisovin},
   year    = {2026},
-  version = {v0.3.1},
+  version = {v0.11.0},
   url     = {https://github.com/usurobor/tsc}
 }
 ```

--- a/docs/alpha/doctrine/3.2.0/SELF-COHERENCE.md
+++ b/docs/alpha/doctrine/3.2.0/SELF-COHERENCE.md
@@ -20,6 +20,16 @@ TSC v3.2.0 measures itself with the v3.2.0-conformant OCaml engine. Three canoni
 
 Aggregate C_Σ = (0.898 × 0.521 × 0.660)^(1/3) = **0.675** — grade C+. The bottleneck is β across two of three targets. The dominant gap is in the engine target (β = 0.225), driven by build artifacts in the corpus.
 
+> **Erratum (2026-07-04, annotation only — measurements unchanged).**
+> The C_Σ column above is the arithmetic-mean reading the engine of
+> this era reported in mechanical mode; the geometric forms
+> (C_Σ^math / C_Σ^num: spec 0.895, engine 0.465, repo 0.621) are in
+> the Aggregate Flags table below, whose trailing note records the
+> distinction. The two tables describe the SAME frozen run in two
+> aggregate forms; this note exists because a witness run flagged the
+> unlabeled column as a same-document contradiction. The v3.2
+> canonical aggregate is the geometric form.
+
 ---
 
 ## Per-Target Results

--- a/docs/alpha/engine/README.md
+++ b/docs/alpha/engine/README.md
@@ -25,6 +25,12 @@ below link the changelog for those.
 
 | Version | Record | Note |
 |---------|--------|------|
+| 0.11.0 | [CHANGELOG.md](../../../CHANGELOG.md) | Official release consolidating the 0.10.1–0.10.5 self-measurement + CM² wave; SELF-MEASURE v3.2.2; held-out commit-reveal standing. |
+| 0.10.5 | [CHANGELOG.md](../../../CHANGELOG.md) | Witness-contract calibration wave (SELF-MEASURE v3.2.1, refuted and withdrawn in v3.2.2). |
+| 0.10.4 | [CHANGELOG.md](../../../CHANGELOG.md) | Release ledger learns k=3 sampling: per-target consistency columns, single-sample rows migrated. |
+| 0.10.3 | [CHANGELOG.md](../../../CHANGELOG.md) | Standing-scope wave: admissibility v2, displacement thresholds, challenger registration, `standing_scope` typed, k=3 witness sampling in measurement CI. |
+| 0.10.2 | [CHANGELOG.md](../../../CHANGELOG.md) | CM² wave: methodologies as measurable objects; new targets `methodology` and `cm-of-cms`. |
+| 0.10.1 | [CHANGELOG.md](../../../CHANGELOG.md) | Self-measurement platformization: `coh self`, witness funnel, external witness route, per-release coherence ledger. |
 | 0.10.0 | [CHANGELOG.md](../../../CHANGELOG.md) | Canonical v3.2 scoring cutover: geometric `C_Σ^math` / `C_Σ^num` under `provenance`; strict v3.2 LLM δ validation; cross-target report surface (#49 wave). |
 | 0.9.0 | [CHANGELOG.md](../../../CHANGELOG.md) | Phase 2 kata progression: comparative, philosophical, adversarial katas; `[[components]]` + ranking runner. |
 | 0.8.0 | [CHANGELOG.md](../../../CHANGELOG.md) | Process enforcement: CHANGELOG release gate in release scripts. |

--- a/docs/beta/governance/DEFECT-HARVESTING.md
+++ b/docs/beta/governance/DEFECT-HARVESTING.md
@@ -1,0 +1,153 @@
+# Design note: defect harvesting from witness runs
+
+Date: 2026-07-04
+Status: Design (Issue 6 of the post-loop stabilization wave; no code
+implemented by this note)
+Companion: [METER-LOOP-DECISION.md](METER-LOOP-DECISION.md) — the
+binding record that stopped score optimization and dispatched this
+design.
+
+## Purpose
+
+The witness route is unstable as a scalar optimizer but productive as
+a defect finder: across the v3.2.3/v3.2.4 experiments it surfaced
+real, citable defects — including defects in code its own maintainer
+had just written (the duplicated barrier in P1, the multi-space error
+strings in the v3.2.4 card surface). This note designs the harvest:
+how a witness finding becomes a reviewed fix, how noise is rejected,
+and how the harvest is measured **without** reintroducing
+Coh-consistency as the objective.
+
+## The defect record
+
+One JSON object per harvested finding, accumulated in a queue file
+(proposed home: `.tsc/meter/defect-queue.jsonl`; exact location is an
+implementation decision):
+
+```json
+{
+  "defect_id": "MFD-0007",
+  "target": "spec",
+  "primary_axis": "beta",
+  "category": "broken-reference",
+  "summary": "Glossary quick-reference cites epsilon default 10^-5 to Core §5; Core only requires epsilon > 0",
+  "evidence": "spec/tsc-glossary.md:1019 vs spec/tsc-core.md §1/§5",
+  "source_runs": [
+    { "run": 28697625576, "samples": ["spec.r1"] },
+    { "run": 28703325203, "samples": ["spec.r1", "spec.r2", "spec.r4", "spec.r5"] }
+  ],
+  "witness_frequency": "5/10 samples across 2 runs",
+  "triage_status": "fixed",
+  "triage_note": "verified against both files; citation was wrong",
+  "resolution_pr": 70,
+  "false_positive_reason": null
+}
+```
+
+Field semantics:
+
+- `defect_id` — stable `MFD-` (meter-found defect) identifier.
+- `target` / `primary_axis` / `category` — the witness's filing,
+  normalized by the maintainer at triage (the meter loop showed
+  witnesses disagree on axis; the QUEUE stores the triaged filing and
+  may note the witness split in `triage_note`).
+- `evidence` — file:line or section citation. **A finding with no
+  citation is not enqueueable.**
+- `source_runs` / `witness_frequency` — where and how often
+  independent samples surfaced it. Job logs carry per-sample
+  observability JSON lines, so frequency is computable from CI logs
+  alone.
+- `triage_status` — `queued | confirmed | fixed | rejected |
+  duplicate | out-of-scope`.
+- `resolution_pr` — set when fixed; `false_positive_reason` — set
+  when rejected.
+
+## Evidence thresholds (enqueue rules)
+
+A finding is enqueued when EITHER:
+
+- **Repetition:** found by ≥ 2 independent samples (any runs), same
+  defect under clustering (same cited surface + same claim, however
+  filed); or
+- **Citation + confirmation:** found by 1 sample with a direct
+  file:line citation that the maintainer verifies against the tree
+  before enqueueing.
+
+Everything else (uncited impressions, "could not verify" hedges,
+bundle-scope observations) is not a defect record; at most it feeds
+target-manifest or instruction work through the normal issue process.
+
+## Triage → CDD issue
+
+- `queued → confirmed`: maintainer reproduces the defect against the
+  current tree (the tree may have moved since the run).
+- `confirmed` findings are batched into a CDD hygiene issue per the
+  issue skill (incoherence, impact, source of truth, ACs, non-goals),
+  normally one issue per wave, one commit per defect cluster, each
+  fix citing its `defect_id` and evidence — the shape used by the
+  post-loop hygiene wave.
+- `rejected` requires `false_positive_reason` — the queue is also the
+  meter's precision record.
+- `duplicate` links the prior `defect_id`; duplicates are COUNTED
+  (see metrics) because rediscovery of an unfixed defect is signal
+  and rediscovery of a fixed one is a regression alarm.
+
+## Worked example (from the v3.2.4 close-out set)
+
+The ε-miscitation defect above is real and was fixed by the post-loop
+hygiene wave (commit "Hygiene C-spec", this branch): found by spec
+witnesses in both the baseline run (28697625576) and the experiment
+run (28703325203), 5 samples total, always filed β, always citing the
+glossary quick-reference row. It passes the repetition threshold
+five times over; triage verified the citation against
+`spec/tsc-core.md` §1/§5 (which declare only ε > 0) and the fix
+corrected the glossary row's value source to the engine default.
+
+A rejection example from the same set: a repo witness reported the
+provenance schema fixture "pinned to v3.2.0 while the protocol
+advanced to v3.2.4" — rejected with
+`false_positive_reason: "report-shape version and witness-protocol
+version are distinct lineages; the report shape IS still v3.2.0
+(report.ml doc comment names the distinction)"`.
+
+## Rejection path for noise
+
+- No citation → never enqueued.
+- Cited but not reproducible against the run's own tree → `rejected`
+  with reason.
+- Cited, reproducible, but a misreading (like the schema-version
+  example) → `rejected` with the explaining reason; if the same
+  misreading recurs across runs, that RECURRENCE is a documentation
+  defect candidate (the surface invites the misreading) — enqueue
+  THAT with the recurrence as evidence.
+
+## Metrics (deliberately not Coh-consistency)
+
+| Metric | Definition |
+|--------|------------|
+| Validated defect yield | confirmed + fixed records per witness run |
+| False-positive rate | rejected / (all triaged), post-human-triage |
+| Duplicate rediscovery rate | duplicates of UNFIXED defects per run (backlog pressure) |
+| Regression rediscovery | duplicates of FIXED defects per run (should be zero; any hit is an alarm) |
+| Time-to-fix | run date → resolution PR merge date per record |
+
+These are the meter's operating numbers going forward. The
+consistency statistic continues to be REPORTED (standing gate,
+unchanged) but is not a target and not a success criterion for any of
+this.
+
+## Later: external calibration hook
+
+Cross-route witnesses (a second provider or a human auditor scoring
+the same bundle) plug into the same queue: their findings get the
+same records with a `route` annotation on `source_runs`, and
+precision can then be compared ACROSS routes — the first rung of the
+diversity ladder named in the 0.10.4 ledger row that same-route
+sampling cannot climb.
+
+## Non-goals
+
+- No automatic PR generation from witness findings — triage is human.
+- No scoring, protocol, or standing change.
+- No new workflow surfaces in this note; implementation (queue file,
+  any tooling) is its own dispatched issue.

--- a/docs/beta/governance/METER-LOOP-DECISION.md
+++ b/docs/beta/governance/METER-LOOP-DECISION.md
@@ -1,0 +1,93 @@
+# Decision record: the meter self-improvement loop is stopped
+
+Date: 2026-07-04
+Status: Binding until superseded by an operator dispatch
+Owner: operator (usurobor)
+
+## Decision
+
+The self-improving meter loop — iterating the witness contract
+(`runtime/SELF-MEASURE.md`) to raise semantic witness consistency — is
+**stopped**. Its pre-registered stop rule fired: two consecutive
+candidates failed their falsification gates.
+
+**Loop stopped: counter 2/2.**
+
+| Candidate | Claim | Gate | Result |
+|-----------|-------|------|--------|
+| SELF-MEASURE v3.2.3 (per-axis defect checklist + medoid-of-k) | per-target k=3 Coh_consistency +0.10 | pre-registered, measured on CI | **FALSIFIED** (+0.0128, noise-level) — counter 1/2 |
+| SELF-MEASURE v3.2.4 (structured defect cards + precedence + k-fair statistic) | full yield; min mean-pairwise ≥ 0.85; ≥ +0.03 over the v3.2.3 k=5 baseline; ≥ 80% cluster axis agreement | pre-registered, measured on CI run 28703325203 | **FAILED** (yield 4/5 on repo; min 0.725; two targets moved negative) — counter 2/2 |
+
+Both experiments' full records (predictions, baselines, measured
+numbers, interpretations) live inside
+`runtime/SELF-MEASURE.md` §3.2 and in the CHANGELOG's
+"Witness-protocol releases (SELF-MEASURE)" index.
+
+## Rejected line of work
+
+**More structured witness filing as a consistency fix.** Two distinct
+structuring mechanisms — a category/severity checklist (v3.2.3) and
+machine-validated defect cards with a filing-precedence rule
+(v3.2.4) — both failed to move the consistency statistic. The
+evidence across both experiments:
+
+- the variance is not in *reporting discipline*: witnesses follow the
+  walk and the card contract when they comply at all;
+- it is not primarily in *discovery*: witnesses converge on a shared
+  defect core (top clusters found by 60–100% of samples);
+- it is in *judgment* — which axis a shared defect belongs to and how
+  many defects an observation counts as — and one witness's counting
+  scale can sit an order of magnitude from its peers';
+- heavier contracts additionally **cost yield**: under v3.2.4,
+  witnesses began skipping the checklist walk entirely (repo 4/5 on
+  the registered run; spec 3/5 on the incidental second draw).
+
+## What is NOT permitted without a new dispatch
+
+No SELF-MEASURE protocol revision whose purpose is to improve the
+consistency statistic may be designed, pre-registered, or run — in
+particular no "v3.2.5-style" prompt/schema tweak. This includes
+indirect forms: no changing k, the spread statistic, the adjudication
+rule, or the instruction's scoring rubric with a consistency-movement
+rationale. There is no discretionary exception; the re-entry
+condition below is the only door.
+
+## Re-entry condition
+
+A new witness-contract consistency experiment requires ALL of:
+
+1. an explicit operator dispatch;
+2. a written theory of variance that explains the v3.2.3 AND v3.2.4
+   measurements and identifies a variance source **not already
+   falsified** by them (i.e. not reporting structure, not discovery
+   overlap);
+3. a pre-registered gate reviewed before any implementation.
+
+## Replacement line of work
+
+The meter remains in service as a **defect finder**, not an
+optimization target:
+
+1. **Pipeline stabilization** — the measurement pipeline is corrected
+   when it is wrong (e.g. the funnel-valid medoid election, PR #69),
+   with regression proof; red CI is reserved for pipeline failures,
+   never for expected witness variance.
+2. **Defect harvesting** — repeated, cited witness findings become
+   CDD issues through the queue defined in
+   [DEFECT-HARVESTING.md](DEFECT-HARVESTING.md); its metrics are
+   defect-yield metrics, not Coh-consistency.
+3. **External calibration design** — cross-route witnesses and
+   externally-anchored calibration (the diversity ladder named in the
+   0.10.4 ledger row) as the eventual consistency evidence, replacing
+   same-route prompt iteration.
+4. **Content hygiene** — meter-found content defects are fixed as
+   ordinary content work, never claimed as meter improvement.
+
+## Standing consequences (unchanged by this record)
+
+- The standing gate stays max-pairwise vs the 0.90 floor;
+  `standing_scope` stays `house-authored-public-commons`.
+- Witness-route measurements publish with failed standing when the
+  floor is missed; low consistency withholds standing, per CM²
+  doctrine.
+- The measurement route samples k=3 (`llm_repeats: 3`).

--- a/docs/beta/guides/OPERATOR-MANUAL.md
+++ b/docs/beta/guides/OPERATOR-MANUAL.md
@@ -187,8 +187,13 @@ coh-self --ingest spec       # validate + ingest a witness response
 | `spec` | theory | Canonical theory surface (`spec/**/*.md`) |
 | `engine` | implementation | OCaml engine (`engine/ocaml/**/*.ml`, build files) |
 | `repo` | aggregate | Full repository: includes `spec` + `engine` targets plus integration surfaces |
+| `methodology` | aggregate | The self-measurement methodology as a corpus: skill declaration, schema, validators, renderer, rendered surfaces, scoring instruction |
+| `cm-of-cms` | aggregate | The 0th coherence methodology as a corpus: CM-of-CMs declaration, comparable schema, instruments, calibration-commons contract |
 
 Targets are declared in `targets/*.tsc` and registered in `targets/registry.tsc`.
+The default self-measurement run (`coh self`, CI) drives `spec`, `engine`,
+and `repo`; `methodology` and `cm-of-cms` are measured on demand
+(`coh --target methodology ...`).
 
 ### Using make
 

--- a/engine/ocaml/README.md
+++ b/engine/ocaml/README.md
@@ -80,8 +80,10 @@ Explicit and bounded; tracked here until closed:
   cross aggregate script-side (same §7.4 geometric mean). Target: extend
   `cross_target` to accept hybrid per-target reports so the engine owns
   that aggregation everywhere.
-- **Witness-contract version constant.** The SELF-MEASURE protocol
-  version appears as a literal in `bin/main.ml` metadata and as prose in
-  the instruction; bumping the protocol requires coordinated edits with
-  no compiler error if one is missed. Target: one shared constant
-  consumed by prompt metadata and the response validator.
+- **Witness-contract version prose.** The engine side is single-sourced
+  (`Types.self_measure_protocol_version`, consumed by prompt metadata
+  and the validator), but the instruction's own title and §3 header are
+  prose: a protocol bump that edits one surface and misses the other
+  compiles cleanly and is caught only at test time
+  (`test_protocol_version_pin` greps both). Residual: no
+  compile-time link between constant and instruction text.

--- a/engine/ocaml/bin/main.ml
+++ b/engine/ocaml/bin/main.ml
@@ -472,8 +472,9 @@ let build_bundle_from_files ~root ~globs =
 (* Witness validation-failure artifact (cycle/51 AC2; review round 2)  *)
 (*
    Every refused witness response — parse failure, base-schema failure,
-   prohibited computed-coherence fields, target mismatch, or strict v3.2
-   delta failure — funnels through this one writer. The raw provider
+   prohibited computed-coherence fields, target mismatch, strict v3.2
+   delta failure, checklist-walk failure, or defect-card failure —
+   funnels through this one writer. The raw provider
    response must already have been written to disk by the caller. No
    coherence report is rendered. There is no mechanical fallback (AC3). *)
 
@@ -629,8 +630,9 @@ let run_llm ~args ~bundle ~ts =
     meta_timestamp = ts;
   } in
   (* Witness-validation funnel: every refusal stage (parse, base schema,
-     prohibited fields, target mismatch, v3.2 delta) writes the same
-     validation-failure artifact and exits (cycle/51 AC1/AC2/AC3). *)
+     prohibited fields, target mismatch, v3.2 delta, checklist,
+     defect_cards) writes the same validation-failure artifact and
+     exits (cycle/51 AC1/AC2/AC3; stages 6-7 added by v3.2.3/v3.2.4). *)
   let result, (d_ab, d_bg, d_ga) =
     validate_witness_or_exit ~args ~bundle ~ts ~raw_path raw_response
   in

--- a/engine/ocaml/lib/cross_target.ml
+++ b/engine/ocaml/lib/cross_target.ml
@@ -13,14 +13,16 @@
     mechanical-only for this cycle; the engine CLI rejects LLM/hybrid/auto
     multi-target requests with an explicit message.
 
-    Strategy: this module does NOT depend on the shape of
-    [Mechanical_scoring.result] gaining new aggregate fields (that is the
-    job of sub-issue #50). Instead, given a [Mechanical_scoring.result]
-    we derive [C_sigma_num] / [C_sigma_math] / degeneracy flags inline by
-    calling [Coherence.aggregate] over the (alpha, beta, gamma) axes of
-    each per-target result. When #50 lands, this module's per-target
-    derivation will route through the canonical result fields; the
-    cross-target math and emitted JSON shape do not change. *)
+    Strategy note (historical + current): this module predates
+    [Mechanical_scoring.result] carrying aggregate fields and derives
+    [C_sigma_num] / [C_sigma_math] / degeneracy flags inline via
+    [Coherence.aggregate] over the (alpha, beta, gamma) axes.
+    [Mechanical_scoring.result] now DOES expose an [aggregate] record
+    (same [Coherence.aggregate], computed once), so this inline
+    derivation is a deliberate second computation of the same values —
+    kept because the cross-target row also honors a caller-supplied
+    [?epsilon]. Routing rows through [r.aggregate] and dropping the
+    re-derivation is the named follow-up. *)
 
 (* ------------------------------------------------------------------ *)
 (* Per-target inline derivation (Option (b) — see self-coherence) *)
@@ -35,9 +37,10 @@ type target_row = {
   tr_numeric_floor_applied  : bool;
 }
 
-(** Canonical epsilon for the numeric aggregate floor. Matches
-    [Coherence.aggregate]'s default and the v3.2.0 provenance contract. *)
-let default_epsilon = 1e-5
+(** Canonical epsilon for the numeric aggregate floor — routes to
+    [Coherence.epsilon_default] (one source, like the scoring modules'
+    [aggregate_epsilon] aliases), per the v3.2.0 provenance contract. *)
+let default_epsilon = Coherence.epsilon_default
 
 (** Derive a [target_row] from a mechanical scoring result.
 

--- a/katas/README.md
+++ b/katas/README.md
@@ -102,7 +102,7 @@ ranking = ["glider", "random-soup"]
 | `[expected].ranking` | string[] | for comparative katas | Component ids ordered highest `C_sigma_num` first; runner asserts observed ranking matches |
 | `[expected.score_range].min` | float | for pass | Minimum acceptable `C_sigma_num` (0.0–1.0; geometric, canonical v3.2) |
 | `[expected.score_range].max` | float | for fail | Maximum `C_sigma_num` for a fail verdict (0.0–1.0; geometric) |
-| `bottleneck_axis` | string | no | Axis that most limits the score; used for diagnostic output |
+| `[expected.score_range].bottleneck_axis` | string | no | Axis that most limits the score; informational diagnostic (runner does not consult it) — lives inside `[expected.score_range]` in existing katas |
 | `[baseline]` | table | no | v0.10.0 (cycle #54) baseline provenance block — `baseline_engine_commit`, `baseline_engine_version`, `baseline_command`, `mode`, `config_hash`, `input_file_hashes`, α, β, γ, `c_sigma_math`, `c_sigma_num`, `zero_component_present`, `numeric_floor_applied`, `rationale_category` (`aggregate-correction`/`scorer-improvement`/`frontier-tightening`). Informational; runner does not consult it. |
 
 ### Comparative katas (Phase 2)
@@ -122,7 +122,6 @@ Quick reference for the `kata.toml` fields, each with type and example:
 - `id` — string; example: `"01-glider"`. Unique kata identifier; matches directory name.
 - `difficulty` — integer 1–5; example: `1`. Ordering key; 1=basic, 5=advanced.
 - `prerequisites` — string[]; example: `["01-glider"]`. Kata IDs that must pass first.
-- `tests` — string[]; example: `["mechanical_basic", "threshold_discrimination"]`. Surfaces exercised.
 - `mode` — string; example: `"mechanical"`. Engine mode for this kata.
 - `description` — string; example: `"Positive control..."`. One-line purpose statement.
 - `input.files` — string[]; example: `["input/glider.md"]`. Input files relative to kata dir (single-bundle katas).
@@ -130,7 +129,7 @@ Quick reference for the `kata.toml` fields, each with type and example:
 - `expected.verdict` — string; example: `"pass"`. Expected outcome: `pass` or `fail`.
 - `expected.ranking` — string[]; example: `["glider", "random-soup"]`. Comparative-kata ranking, highest C_Σ first (Phase 2).
 - `expected.score_range` — object; example: `{ min = 0.87, max = 1.0 }`. C_Σ bounds (single-bundle katas).
-- `expected.bottleneck_axis` — string; example: `"gamma"`. Optional axis diagnostic.
+- `expected.score_range.bottleneck_axis` — string; example: `"gamma"`. Optional axis diagnostic (informational; runner does not consult it).
 
 ## Runner invocation
 

--- a/runtime/SELF-MEASURE.md
+++ b/runtime/SELF-MEASURE.md
@@ -295,7 +295,9 @@ this run exposed: witness-medoid elects among numerically-complete
 samples without funnel validity (an invalid sample can be
 adjudicated, failing ingest), and three v3.2.4 error strings in
 response_schema.ml carry baked multi-space runs. The loop counter is
-exhausted; next protocol change requires operator dispatch.
+exhausted; next protocol change requires operator dispatch — the
+binding stop rule, rejected line, and re-entry condition are recorded
+in docs/beta/governance/METER-LOOP-DECISION.md.
 
 **Confidence rubric**: 0.9 — you read every file and your findings are
 all directly cited; 0.75 — some claims reference material outside the

--- a/schemas/skill.cue
+++ b/schemas/skill.cue
@@ -9,8 +9,9 @@
 // Convention imported from cnos (schemas/skill.cue there): schemas are
 // open (`...` at the end) so package-local extension keys pass through —
 // loaders MUST ignore unknown keys. Hard-gate fields fail validation if
-// missing; there is no exception ledger in tsc (one skill today — add a
-// ledger only when debt actually exists).
+// missing; there is no exception ledger in tsc (two skills today,
+// #SelfMeasure and #CMOfCMs — add a ledger only when debt actually
+// exists).
 
 package skill
 

--- a/spec/tsc-core.md
+++ b/spec/tsc-core.md
@@ -64,7 +64,7 @@ ______________________________________________________________________
 
 **A4 (Self-Articulation Stability):** Aₐ ∘ Aₐ ≅ Aₐ (idempotent up to noise).
 
-**Note:** Formal noise model deferred to implementation guidance (§12).
+**Note:** No formal noise model is specified in this document; ≅ is read operationally. §12's implementation notes give numerical-stability practice, not a noise model.
 
 ______________________________________________________________________
 

--- a/spec/tsc-glossary.md
+++ b/spec/tsc-glossary.md
@@ -1003,7 +1003,7 @@ What's not okay: silently changing parameters mid-stream and pretending measurem
 
 Think of it like changing the ruler while measuring. If you measure something as 10 inches, then change to a centimeter ruler and measure 25, you can't say "it grew from 10 to 25." You changed the measurement units.
 
-Same with TSC parameters. Change them if needed, but **declare** the change. (See TSC Core §2.1, Operational §6)
+Same with TSC parameters. Change them if needed, but **declare** the change. (See TSC Core §1 Parameters, Operational §6)
 
 ______________________________________________________________________
 
@@ -1016,8 +1016,8 @@ ______________________________________________________________________
 | λ_ab      | Pairwise sensitivity                | tuned        | Core §3            |
 | φ         | Barrier transform δ → D             | δ/(1−δ)      | Core §3.2          |
 | η_φ       | Barrier clip near δ=1               | 10⁻¹²        | Core §3.2, §12     |
-| ε         | Numerical floor                     | 10⁻⁵         | Core §5            |
-| M         | α evaluator cap (≥ 3)               | 10 (example) | C≡ §3.1            |
+| ε         | Numerical floor (Core: ε>0 only)    | 10⁻⁵ (engine default) | Core §1, §5; engine `Coherence.epsilon_default` |
+| M         | α evaluator cap                     | ≥ 3 (no default; 10 illustrative) | C≡ §3.1            |
 | **Θ**     | **Decision threshold**              | **0.75**     | **Operational §5** |
 | δ_CI      | CI width tolerance                  | 0.20         | Operational §5     |
 | Z_crit    | OOD threshold                       | 2.5          | Operational §5     |

--- a/spec/tsc-observation-dynamics.md
+++ b/spec/tsc-observation-dynamics.md
@@ -3,7 +3,7 @@ Formal Specification of Observer Construction, Verification, Epistemic Refinemen
 
 Version: v1.0.13
 Status: Proposed Extension Specification
-Status consequence: verdict-bearing measurement (Core §5, Operational §5) does not depend on this extension; engines MAY implement its witnesses (the canonical engine emits the W2 gauge witness in provenance). Promotion to Normative follows the spec-release process (`CHANGELOG.md` § Spec releases).
+Status consequence: verdict-bearing measurement (Core §5, Operational §5) does not depend on this extension; engines MAY implement this extension's witnesses (e.g. BudgetGroundingWitness, Definition 13.46). The W2 gauge witness the canonical engine emits in provenance is an Operational §1 witness, not one of this extension's. Promotion to Normative follows the spec-release process (`CHANGELOG.md` § Spec releases).
 Artifact: Specification
 Changelog: `CHANGELOG.md` § Spec releases
 

--- a/spec/tsc-oper.md
+++ b/spec/tsc-oper.md
@@ -435,8 +435,8 @@ ______________________________________________________________________
 **Release artifacts:**
 
 - Updated spec files
-- Self-coherence report (docs/self-coherence-v3.0.1.md)
-- Provenance bundle (coherence_report.json)
+- Self-coherence report (`docs/alpha/doctrine/{version}/SELF-COHERENCE.md`, per §7.3)
+- Provenance bundle (generated into `.tsc/self/` by the self-measurement surface, per §7.3)
 - Implementation reference (if updated)
 
 **Version increment:**


### PR DESCRIPTION
## Description

Issues 4–6 of the post-loop stabilization wave (dispatched by operator review after the v3.2.4 gate failure; Issues 1–3 landed with #69). Content and governance only — no protocol, scoring, workflow-behavior, or version change; no meter-improvement claim; no loop-counter reset.

Fixes #(no tracked issue — wave dispatched by operator review)

## Type of Change

- [x] Documentation update
- [x] Bug fix (non-breaking change that fixes an issue) — content-level citation/claim defects

## Changes Made

**Issue 4 — meter-found content hygiene** (one commit per cluster; every defect below carries its witness evidence):

*Hygiene C-spec (`ea433f0`)*
- `spec/tsc-oper.md` §8 release artifacts: stale `docs/self-coherence-v3.0.1.md` + `coherence_report.json` → the §7.3 doctrine/`.tsc/self` conventions. Evidence: 3/5 spec witnesses, run 28703325203 (the α/γ split cluster).
- `spec/tsc-glossary.md` quick reference: ε default 10⁻⁵ was cited to Core §5 (which only requires ε>0; the default is the engine's `Coherence.epsilon_default`); M's "10" cited to C≡ §3.1 (which only requires M ≥ 3). Evidence: 4/5 spec witnesses.
- `spec/tsc-glossary.md`: nonexistent "Core §2.1" citation → Core §1 Parameters. Evidence: spec r5.
- `spec/tsc-core.md` A4 note deferred a "formal noise model" to §12, which contains none; now honest. Evidence: 2 witnesses.
- `spec/tsc-observation-dynamics.md` status note: W2 witness ownership disambiguated (Operational §1, not this extension). Evidence: 2 witnesses.

*Hygiene C-engine (`aaa7f2f`)*
- `engine/ocaml/README.md` known-debt: "protocol version is a literal in bin/main.ml" was stale since Issue A centralized it; entry now states the actual residual (instruction prose not compiler-linked, CI pin test). Evidence: 3/5 engine witnesses across two runs.
- `bin/main.ml` funnel comments named 5 of 7 refusal stages; both sites now name `checklist` and `defect_cards`. Evidence: engine r5.
- `cross_target.ml`: bare `1e-5` literal → `Coherence.epsilon_default` (identical value, now single-sourced); the stale "waiting on #50" strategy comment rewritten to the actual current relationship with `mechanical_scoring.mli`'s shipped aggregate fields. Evidence: engine r1/r2/r3.

*Hygiene C-docs (`4a524e7`)*
- `README.md` citation block v0.3.1 → v0.11.0. Evidence: 4 repo witnesses across two runs.
- `OPERATOR-MANUAL.md` targets table: `methodology` + `cm-of-cms` rows added, with a note on which targets the default run drives. Evidence: repo r1 + baseline r4.
- `docs/alpha/engine/README.md` version table extended 0.10.1–0.11.0 from CHANGELOG rows. Evidence: repo r5.
- `docs/alpha/doctrine/3.2.0/SELF-COHERENCE.md`: dated erratum **annotation** (measurements untouched) labeling the summary C_Σ column as the era's arithmetic-mean reading vs the geometric Aggregate Flags — a witness read the unlabeled column as a same-document contradiction. Evidence: repo r1, baseline run.

*Hygiene C-meta (`b35e1b5`)*
- `schemas/skill.cue` "one skill today" → two skill types (#SelfMeasure, #CMOfCMs). Evidence: repo r5.
- `katas/README.md`: three disagreeing `bottleneck_axis` placements reconciled to the actual `[expected.score_range]` placement; unused `tests` quick-ref field removed. Evidence: repo r3, verified against kata.toml files and the runner.
- `CHANGELOG.md`: new "Witness-protocol releases (SELF-MEASURE)" index recording the v3.2.3/v3.2.4 migrations and their falsified/failed verdicts — the protocol's migration history was unrecorded at the designated process-history location. Evidence: repo r3 in both runs. Not a release row; the engine ledger is untouched.

**Issue 5 — decision record (`262ce2d`)**: `docs/beta/governance/METER-LOOP-DECISION.md` — loop stopped (counter 2/2), failed candidates v3.2.3/v3.2.4, rejected line (structured witness filing as consistency fix), replacement line (stabilization + defect harvesting + external calibration + content hygiene), re-entry condition (operator dispatch + unfalsified variance theory + pre-registered gate; no discretionary back door). The v3.2.4 experiment record in `runtime/SELF-MEASURE.md` links to it.

**Issue 6 — defect-harvesting design (`262ce2d`)**: `docs/beta/governance/DEFECT-HARVESTING.md` — defect record schema, enqueue thresholds, triage→CDD path, rejection path, worked example (the ε-miscitation, fixed by this very wave) and worked rejection (the schema-version misreading), and metrics that are deliberately not Coh-consistency. Design only; no code.

## Testing

**Test commands run:**

```bash
dune build
dune runtest
scripts/ci/self-measure-smoke.sh <fresh binary>
scripts/ci/validate-skill-frontmatter.sh
scripts/render-self-measure.sh --check
```

**New tests added:**

- [ ] No (explain why not) — content/docs wave; the only source change (`cross_target.ml` epsilon routing) is value-identical and covered by the existing cross-target suite, which passes.

**Manual testing performed:**

Every fixed defect was verified against the current tree before editing (citations checked against cited sections; kata placement checked against kata.toml files and the runner; SELF-COHERENCE numbers traced to the arithmetic/geometric distinction its own flags table records).

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] New and existing unit tests pass locally with my changes (`dune runtest`)
- [x] I have updated CHANGELOG.md (witness-protocol index; deliberately NOT a release row)

## Breaking Changes

None.

## Additional Context

Score movement in the k=3 witness jobs on this PR is observation only, per the Issue 4 proof rule: this wave does not use score movement as proof of correctness, and it makes no meter-improvement claim.

Out of scope, parked with reasons: the obs-dynamics v1.0.12 base-definition absence (structural bundle-scope work, not a citation fix); the `examples/`+`tests/` top-level directory claims in README/ARCHITECTURE (needs an operator call: create the dirs or amend the maps).

## Reviewer Notes

The clean story: failed-experiment close-out (#69) stays untouched; this wave is the harvest of what the meter found plus the governance that stops the loop from restarting itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ks8wtULXPtFaehDbnEGgdr

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ks8wtULXPtFaehDbnEGgdr)_